### PR TITLE
feat(runtime): prepare serve for cloud deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,11 @@ LORE_ENV=staging
 # Server bind address (default: 127.0.0.1 for local, 0.0.0.0 for staging)
 LORE_HOST=0.0.0.0
 
-# Server port (default: 7437)
+# Preferred server port (takes precedence over PORT when both are set)
 LORE_PORT=7437
+
+# Cloud runtime fallback port (used when LORE_PORT is unset)
+PORT=
 
 # Canonical base URL — REQUIRED in staging, used for OAuth callbacks and admin links
 LORE_BASE_URL=https://lore.yourdomain.com
@@ -20,6 +23,10 @@ LORE_COOKIE_SECURE=true
 # Data directory for SQLite database — mount this as a Docker volume.
 # WAL mode also writes lore.db-wal and lore.db-shm in this same directory.
 LORE_DATA_DIR=/data
+
+# Forward-compatible external DB URL (syntax-validated only in this phase).
+# Lore still uses local SQLite as the active backend.
+DATABASE_URL=
 
 # Google OAuth (optional — admin login)
 LORE_GOOGLE_CLIENT_ID=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
         with:
           go-version: "1.25"
 
-      - name: Validate staging artifacts script
+      - name: Validate runtime/deployment artifacts script
         run: ./scripts/validate-staging.sh
 
-      - name: Prepare staging env for compose validation
+      - name: Prepare compose env for Docker syntax validation
         run: cp .env.example .env.staging
 
-      - name: Validate staging compose syntax
+      - name: Validate Docker compose syntax
         run: docker compose -f docker-compose.staging.yml config --quiet
 
       - name: Run unit tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,13 @@ Notion Project URL: https://www.notion.so/33e8846684b181999712ef3828bb4b34
 
 When working on this project, load the relevant skill(s) BEFORE writing any code.
 
+## Skill Source Policy
+
+- Use project-local skills first.
+- If a tool-global skill is needed, use the active OpenCode skill set.
+- Do **not** resolve or load global home-directory Claude skills from `~/.claude/skills/` for this project.
+- Project-local `.claude/` folders created by setup are adapter folders, not permission to use global `~/.claude/skills/` as a source of truth.
+
 ## How to Use
 
 1. Check the trigger column to find skills that match your current task

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,3 +194,5 @@ This links repo `skills/*` into project-local:
 - `.claude/skills/*`
 - `.codex/skills/*`
 - `.gemini/skills/*`
+
+These are project-local adapter folders. They do **not** imply that global home-directory skills from `~/.claude/skills/` should be used as part of Lore's runtime skill resolution.

--- a/DOCS.md
+++ b/DOCS.md
@@ -87,7 +87,7 @@ lore/
 ## CLI Commands
 
 ```
-lore serve [port]       Start HTTP API server (default: 7437)
+lore serve [port]       Start HTTP API server (port precedence: arg > LORE_PORT > PORT > 7437)
 lore mcp                Start MCP server (stdio transport)
 lore tui                Launch interactive terminal UI
 lore search <query>     Search memories [--type TYPE] [--project PROJECT] [--scope SCOPE] [--limit N]
@@ -110,7 +110,9 @@ lore help               Show help
 | Variable | Description | Default |
 |---|---|---|
 | `LORE_DATA_DIR` | Override data directory | `~/.lore` |
-| `LORE_PORT` | Override HTTP server port | `7437` |
+| `LORE_PORT` | Preferred HTTP server port for `lore serve` | `7437` |
+| `PORT` | Cloud-host fallback port when `LORE_PORT` is unset | unset |
+| `DATABASE_URL` | Forward-compatible storage input (syntax-validated only; SQLite stays active) | unset |
 | `LORE_PROJECT` | Override project name for MCP server | auto-detected via git |
 
 ---
@@ -204,7 +206,7 @@ The TUI uses dedicated store methods that don't filter by session status (unlike
 
 ## HTTP API Endpoints
 
-All endpoints return JSON. Server listens on `127.0.0.1:7437`.
+All endpoints return JSON. `lore serve` listens using runtime config (`[port]` arg → `LORE_PORT` → `PORT` → `7437`) and host defaults (`127.0.0.1` local, `0.0.0.0` staging).
 
 ### Health
 

--- a/cmd/lore/docker_staging_test.go
+++ b/cmd/lore/docker_staging_test.go
@@ -57,11 +57,11 @@ func TestDockerStagingRequiredFilesExist(t *testing.T) {
 	}
 }
 
-func TestEnvExampleContainsRequiredStagingVariables(t *testing.T) {
+func TestEnvExampleContainsRuntimeAndStorageVariables(t *testing.T) {
 	root := repoRootFromCwd(t)
 	content := mustReadFile(t, filepath.Join(root, ".env.example"))
 
-	requiredVars := []string{"LORE_ENV", "LORE_BASE_URL", "LORE_JWT_SECRET"}
+	requiredVars := []string{"LORE_ENV", "LORE_BASE_URL", "LORE_JWT_SECRET", "LORE_PORT", "PORT", "DATABASE_URL"}
 	for _, requiredVar := range requiredVars {
 		requiredVar := requiredVar
 		t.Run(requiredVar, func(t *testing.T) {
@@ -69,6 +69,26 @@ func TestEnvExampleContainsRequiredStagingVariables(t *testing.T) {
 				t.Fatalf(".env.example must include %s", requiredVar)
 			}
 		})
+	}
+}
+
+func TestRuntimeDocsDescribePortPrecedenceAndSQLiteBehavior(t *testing.T) {
+	root := repoRootFromCwd(t)
+
+	installation := mustReadFile(t, filepath.Join(root, "docs", "INSTALLATION.md"))
+	if !strings.Contains(installation, "LORE_PORT") || !strings.Contains(installation, "PORT") {
+		t.Fatalf("docs/INSTALLATION.md must describe LORE_PORT and PORT runtime inputs")
+	}
+	if !strings.Contains(installation, "DATABASE_URL") {
+		t.Fatalf("docs/INSTALLATION.md must mention DATABASE_URL acceptance")
+	}
+
+	docs := mustReadFile(t, filepath.Join(root, "DOCS.md"))
+	if !strings.Contains(docs, "LORE_PORT") || !strings.Contains(docs, "PORT") {
+		t.Fatalf("DOCS.md must describe serve port precedence")
+	}
+	if !strings.Contains(docs, "SQLite") {
+		t.Fatalf("DOCS.md must preserve SQLite runtime guidance")
 	}
 }
 

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -68,6 +68,7 @@ var (
 	resolveMCPTools        = mcp.ResolveTools
 	serveMCP               = mcpserver.ServeStdio
 	newMCPHTTPHandler      = mcp.NewHTTPHandler
+	mountAdmin             = admin.Mount
 
 	// detectProject is injectable for testing; wraps project.DetectProject.
 	detectProject = project.DetectProject
@@ -192,12 +193,17 @@ func main() {
 // ─── Commands ────────────────────────────────────────────────────────────────
 
 func cmdServe(cfg store.Config) {
-	runtimeCfg, err := loadRuntimeConfig(cfg, os.Args[2:])
+	runtimeCfg, err := loadRuntimeConfig(os.Args[2:])
 	if err != nil {
 		fatal(err)
 	}
 
-	cfg.DataDir = runtimeCfg.DataDir
+	storageCfg, err := loadStorageConfig(cfg)
+	if err != nil {
+		fatal(err)
+	}
+
+	cfg = storageCfg.Apply(cfg)
 
 	// Allow: lore serve --dev-auth
 	devAuth := false
@@ -268,7 +274,7 @@ func cmdServe(cfg store.Config) {
 
 	// Mount admin routes on the server's mux.
 	mux := srv.Handler().(*http.ServeMux)
-	admin.Mount(mux, adminCfg)
+	mountAdmin(mux, adminCfg)
 	log.Printf("[lore] admin panel: %s/admin/", runtimeCfg.BaseURL)
 	if devAuth {
 		log.Printf("[lore] WARN: --dev-auth is enabled — do NOT use in production")
@@ -1594,7 +1600,7 @@ Usage:
   lore <command> [arguments]
 
 Commands:
-  serve [port]       Start HTTP API server (default: 7437)
+	serve [port]       Start HTTP API server (port precedence: arg > LORE_PORT > PORT > 7437)
   mcp [--tools=PROFILE] [--project=NAME]
                      Start MCP server (stdio transport, for any AI agent)
                        Profiles: agent (11 tools), admin (4 tools), all (default, 15)
@@ -1634,8 +1640,10 @@ Commands:
   help               Show this help
 
 Environment:
-  LORE_DATA_DIR    Override data directory (default: ~/.lore)
-  LORE_PORT        Override HTTP server port (default: 7437)
+  LORE_DATA_DIR    Override SQLite data directory (default: ~/.lore)
+  LORE_PORT        Preferred HTTP server port for serve (default: 7437)
+  PORT             Cloud runtime fallback port when LORE_PORT is unset
+  DATABASE_URL     Forward-compatible storage URL (syntax-validated only; SQLite remains active)
   LORE_PROJECT     Override auto-detected project name for MCP server
 
 MCP Configuration (add to your agent's config):

--- a/cmd/lore/main_extra_test.go
+++ b/cmd/lore/main_extra_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alferio94/lore/internal/admin"
 	"github.com/alferio94/lore/internal/mcp"
 	engramsrv "github.com/alferio94/lore/internal/server"
 	"github.com/alferio94/lore/internal/setup"
@@ -101,6 +102,7 @@ func stubRuntimeHooks(t *testing.T) {
 	oldSyncImport := syncImport
 	oldSyncExport := syncExport
 	oldCheckForUpdates := checkForUpdates
+	oldMountAdmin := mountAdmin
 
 	storeNew = store.New
 	newHTTPServer = func(s *store.Store, cfg engramsrv.Config) *engramsrv.Server { return engramsrv.NewWithConfig(s, cfg) }
@@ -143,6 +145,7 @@ func stubRuntimeHooks(t *testing.T) {
 	checkForUpdates = func(string) versioncheck.CheckResult {
 		return versioncheck.CheckResult{Status: versioncheck.StatusUpToDate}
 	}
+	mountAdmin = admin.Mount
 
 	t.Cleanup(func() {
 		storeNew = oldStoreNew
@@ -168,6 +171,7 @@ func stubRuntimeHooks(t *testing.T) {
 		syncImport = oldSyncImport
 		syncExport = oldSyncExport
 		checkForUpdates = oldCheckForUpdates
+		mountAdmin = oldMountAdmin
 	})
 }
 
@@ -192,27 +196,35 @@ func TestCmdServeParsesPortAndErrors(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		envPort   string
+		lorePort  string
+		portEnv   string
 		argPort   string
 		wantPort  int
 		startErr  error
 		wantFatal bool
 	}{
 		{name: "default port", wantPort: 7437},
-		{name: "env port", envPort: "8123", wantPort: 8123},
-		{name: "arg overrides env", envPort: "8123", argPort: "9001", wantPort: 9001},
-		{name: "invalid env keeps default", envPort: "nope", wantPort: 7437},
-		{name: "invalid arg keeps env", envPort: "8123", argPort: "bad", wantPort: 8123},
+		{name: "PORT fallback", portEnv: "7000", wantPort: 7000},
+		{name: "LORE_PORT takes precedence over PORT", lorePort: "8123", portEnv: "7000", wantPort: 8123},
+		{name: "arg overrides env", lorePort: "8123", portEnv: "7000", argPort: "9001", wantPort: 9001},
+		{name: "invalid LORE_PORT falls back to PORT", lorePort: "nope", portEnv: "7000", wantPort: 7000},
+		{name: "invalid arg keeps env", lorePort: "8123", argPort: "bad", wantPort: 8123},
+		{name: "invalid env keeps default", lorePort: "nope", portEnv: "also-bad", wantPort: 7437},
 		{name: "start failure", wantPort: 7437, startErr: errors.New("listen failed"), wantFatal: true},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			stubExitWithPanic(t)
-			if tc.envPort != "" {
-				t.Setenv("LORE_PORT", tc.envPort)
+			if tc.lorePort != "" {
+				t.Setenv("LORE_PORT", tc.lorePort)
 			} else {
 				t.Setenv("LORE_PORT", "")
+			}
+			if tc.portEnv != "" {
+				t.Setenv("PORT", tc.portEnv)
+			} else {
+				t.Setenv("PORT", "")
 			}
 
 			args := []string{"lore", "serve"}
@@ -1014,6 +1026,96 @@ func TestCmdServeUsesProjectHintFromEnv(t *testing.T) {
 
 	if capturedHint != "my-env-project" {
 		t.Fatalf("expected projectHint=%q, got %q", "my-env-project", capturedHint)
+	}
+}
+
+// TestCmdServeRuntimeContractIntegrationLike verifies runtime/storage wiring
+// together with mounted HTTP contracts in one end-to-end-ish cmdServe pass.
+func TestCmdServeRuntimeContractIntegrationLike(t *testing.T) {
+	cfg := testConfig(t)
+	stubRuntimeHooks(t)
+
+	storageDir := t.TempDir()
+	t.Setenv("LORE_ENV", "local")
+	t.Setenv("LORE_HOST", "127.0.0.1")
+	t.Setenv("LORE_PORT", "")
+	t.Setenv("PORT", "7666")
+	t.Setenv("LORE_DATA_DIR", storageDir)
+	t.Setenv("DATABASE_URL", "postgres://lore:secret@db.internal:5432/lore")
+	t.Setenv("LORE_PROJECT", "Runtime-Project")
+	withArgs(t, "lore", "serve", "--dev-auth")
+
+	seenStoreDataDir := ""
+	seenStoreDatabaseURL := ""
+	seenServerHost := ""
+	seenServerPort := 0
+	seenProjectHint := ""
+	adminMounted := false
+
+	storeNew = func(in store.Config) (*store.Store, error) {
+		seenStoreDataDir = in.DataDir
+		seenStoreDatabaseURL = in.DatabaseURL
+		return store.New(in)
+	}
+	newHTTPServer = func(s *store.Store, cfg engramsrv.Config) *engramsrv.Server {
+		seenServerHost = cfg.Host
+		seenServerPort = cfg.Port
+		return engramsrv.NewWithConfig(s, cfg)
+	}
+	newMCPHTTPHandler = func(_ *store.Store, projectHint string) http.Handler {
+		seenProjectHint = projectHint
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+	}
+	mountAdmin = func(mux *http.ServeMux, cfg admin.AdminConfig) {
+		adminMounted = true
+		if !cfg.DevAuth {
+			t.Fatalf("expected DevAuth=true when --dev-auth flag is present")
+		}
+		admin.Mount(mux, cfg)
+	}
+
+	startHTTP = func(srv *engramsrv.Server) error {
+		mcpReq := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		mcpRec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(mcpRec, mcpReq)
+		if mcpRec.Code == http.StatusNotFound {
+			return fmt.Errorf("expected /mcp route to be mounted")
+		}
+
+		adminReq := httptest.NewRequest(http.MethodGet, "/admin/", nil)
+		adminRec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(adminRec, adminReq)
+		if adminRec.Code == http.StatusNotFound {
+			return fmt.Errorf("expected /admin route to be mounted")
+		}
+
+		return nil
+	}
+
+	_, stderr, recovered := captureOutputAndRecover(t, func() { cmdServe(cfg) })
+	if recovered != nil {
+		t.Fatalf("expected clean cmdServe run, got panic=%v stderr=%q", recovered, stderr)
+	}
+
+	if seenServerHost != "127.0.0.1" {
+		t.Fatalf("server host = %q, want 127.0.0.1", seenServerHost)
+	}
+	if seenServerPort != 7666 {
+		t.Fatalf("server port = %d, want 7666 from PORT fallback", seenServerPort)
+	}
+	if seenStoreDataDir != storageDir {
+		t.Fatalf("store DataDir = %q, want %q", seenStoreDataDir, storageDir)
+	}
+	if seenStoreDatabaseURL == "" {
+		t.Fatalf("expected store config to retain DATABASE_URL")
+	}
+	if seenProjectHint != "runtime-project" {
+		t.Fatalf("project hint = %q, want normalized runtime-project", seenProjectHint)
+	}
+	if !adminMounted {
+		t.Fatalf("expected admin routes to be mounted")
 	}
 }
 

--- a/cmd/lore/main_test.go
+++ b/cmd/lore/main_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alferio94/lore/internal/admin"
 	"github.com/alferio94/lore/internal/mcp"
 	"github.com/alferio94/lore/internal/obsidian"
 	"github.com/alferio94/lore/internal/server"
@@ -124,10 +125,10 @@ func mustSeedObservation(t *testing.T, cfg store.Config, sessionID, project, typ
 }
 
 func TestLoadRuntimeConfigLocalDefaults(t *testing.T) {
-	cfg := testConfig(t)
 	t.Setenv("LORE_ENV", "")
 	t.Setenv("LORE_HOST", "")
 	t.Setenv("LORE_PORT", "")
+	t.Setenv("PORT", "")
 	t.Setenv("LORE_BASE_URL", "")
 	t.Setenv("LORE_JWT_SECRET", "")
 	t.Setenv("LORE_COOKIE_SECURE", "")
@@ -136,7 +137,7 @@ func TestLoadRuntimeConfigLocalDefaults(t *testing.T) {
 	t.Setenv("LORE_GITHUB_CLIENT_ID", "")
 	t.Setenv("LORE_GITHUB_CLIENT_SECRET", "")
 
-	runtimeCfg, err := loadRuntimeConfig(cfg, []string{})
+	runtimeCfg, err := loadRuntimeConfig([]string{})
 	if err != nil {
 		t.Fatalf("loadRuntimeConfig() error = %v", err)
 	}
@@ -156,16 +157,13 @@ func TestLoadRuntimeConfigLocalDefaults(t *testing.T) {
 	if runtimeCfg.CookieSecure {
 		t.Fatalf("CookieSecure = true, want false")
 	}
-	if runtimeCfg.DataDir != cfg.DataDir {
-		t.Fatalf("DataDir = %q, want %q", runtimeCfg.DataDir, cfg.DataDir)
-	}
 }
 
 func TestLoadRuntimeConfigStagingGuardrails(t *testing.T) {
-	cfg := testConfig(t)
 	t.Setenv("LORE_ENV", "staging")
 	t.Setenv("LORE_HOST", "")
 	t.Setenv("LORE_PORT", "")
+	t.Setenv("PORT", "")
 	t.Setenv("LORE_COOKIE_SECURE", "")
 	t.Setenv("LORE_GOOGLE_CLIENT_ID", "")
 	t.Setenv("LORE_GOOGLE_CLIENT_SECRET", "")
@@ -176,7 +174,7 @@ func TestLoadRuntimeConfigStagingGuardrails(t *testing.T) {
 		t.Setenv("LORE_BASE_URL", "")
 		t.Setenv("LORE_JWT_SECRET", "secret")
 
-		_, err := loadRuntimeConfig(cfg, nil)
+		_, err := loadRuntimeConfig(nil)
 		if err == nil || !strings.Contains(err.Error(), "LORE_BASE_URL is required when LORE_ENV=staging") {
 			t.Fatalf("expected LORE_BASE_URL staging error, got %v", err)
 		}
@@ -186,7 +184,7 @@ func TestLoadRuntimeConfigStagingGuardrails(t *testing.T) {
 		t.Setenv("LORE_BASE_URL", "https://staging.lore.local")
 		t.Setenv("LORE_JWT_SECRET", "")
 
-		_, err := loadRuntimeConfig(cfg, nil)
+		_, err := loadRuntimeConfig(nil)
 		if err == nil || !strings.Contains(err.Error(), "LORE_JWT_SECRET is required when LORE_ENV=staging") {
 			t.Fatalf("expected LORE_JWT_SECRET staging error, got %v", err)
 		}
@@ -196,7 +194,7 @@ func TestLoadRuntimeConfigStagingGuardrails(t *testing.T) {
 		t.Setenv("LORE_BASE_URL", "https://staging.lore.local")
 		t.Setenv("LORE_JWT_SECRET", "secret")
 
-		runtimeCfg, err := loadRuntimeConfig(cfg, nil)
+		runtimeCfg, err := loadRuntimeConfig(nil)
 		if err != nil {
 			t.Fatalf("loadRuntimeConfig() error = %v", err)
 		}
@@ -213,17 +211,157 @@ func TestLoadRuntimeConfigStagingGuardrails(t *testing.T) {
 }
 
 func TestLoadRuntimeConfigInvalidValues(t *testing.T) {
-	cfg := testConfig(t)
-
 	t.Setenv("LORE_ENV", "prod")
-	if _, err := loadRuntimeConfig(cfg, nil); err == nil || !strings.Contains(err.Error(), "invalid LORE_ENV") {
+	if _, err := loadRuntimeConfig(nil); err == nil || !strings.Contains(err.Error(), "invalid LORE_ENV") {
 		t.Fatalf("expected invalid env error, got %v", err)
 	}
 
 	t.Setenv("LORE_ENV", "local")
 	t.Setenv("LORE_COOKIE_SECURE", "definitely")
-	if _, err := loadRuntimeConfig(cfg, nil); err == nil || !strings.Contains(err.Error(), "invalid LORE_COOKIE_SECURE") {
+	if _, err := loadRuntimeConfig(nil); err == nil || !strings.Contains(err.Error(), "invalid LORE_COOKIE_SECURE") {
 		t.Fatalf("expected invalid cookie bool error, got %v", err)
+	}
+}
+
+func TestAdminGenerateSecretProducesHexSecret(t *testing.T) {
+	secret := adminGenerateSecret()
+	if len(secret) != 32 {
+		t.Fatalf("secret length = %d, want 32 hex chars", len(secret))
+	}
+	for _, b := range secret {
+		if !((b >= '0' && b <= '9') || (b >= 'a' && b <= 'f')) {
+			t.Fatalf("secret contains non-hex byte %q", b)
+		}
+	}
+}
+
+func TestResolveHomeFallback(t *testing.T) {
+	t.Run("uses USERPROFILE when present", func(t *testing.T) {
+		t.Setenv("USERPROFILE", "/tmp/userprofile")
+		t.Setenv("HOME", "")
+		t.Setenv("LOCALAPPDATA", "")
+		if got := resolveHomeFallback(); got != "/tmp/userprofile" {
+			t.Fatalf("resolveHomeFallback() = %q, want /tmp/userprofile", got)
+		}
+	})
+
+	t.Run("derives parent from LOCALAPPDATA", func(t *testing.T) {
+		t.Setenv("USERPROFILE", "")
+		t.Setenv("HOME", "")
+		t.Setenv("LOCALAPPDATA", "/Users/alice/AppData/Local")
+		if got := resolveHomeFallback(); got != "/Users/alice" {
+			t.Fatalf("resolveHomeFallback() = %q, want /Users/alice", got)
+		}
+	})
+
+	t.Run("returns empty when no hints exist", func(t *testing.T) {
+		t.Setenv("USERPROFILE", "")
+		t.Setenv("HOME", "")
+		t.Setenv("LOCALAPPDATA", "")
+		if got := resolveHomeFallback(); got != "" {
+			t.Fatalf("resolveHomeFallback() = %q, want empty", got)
+		}
+	})
+}
+
+func TestAdminBuildOAuthConfigsWiresCallbacks(t *testing.T) {
+	base := admin.AdminConfig{
+		BaseURL:            "https://lore.example",
+		GoogleClientID:     "google-id",
+		GoogleClientSecret: "google-secret",
+		GitHubClientID:     "github-id",
+		GitHubClientSecret: "github-secret",
+	}
+
+	built := adminBuildOAuthConfigs(base)
+	if built.GoogleOAuth == nil {
+		t.Fatalf("expected GoogleOAuth config when credentials are set")
+	}
+	if built.GoogleOAuth.RedirectURL != "https://lore.example/admin/auth/callback/google" {
+		t.Fatalf("google redirect = %q", built.GoogleOAuth.RedirectURL)
+	}
+	if built.GithubOAuth == nil {
+		t.Fatalf("expected GithubOAuth config when credentials are set")
+	}
+	if built.GithubOAuth.RedirectURL != "https://lore.example/admin/auth/callback/github" {
+		t.Fatalf("github redirect = %q", built.GithubOAuth.RedirectURL)
+	}
+
+	withoutCreds := adminBuildOAuthConfigs(admin.AdminConfig{BaseURL: "https://lore.example"})
+	if withoutCreds.GoogleOAuth != nil || withoutCreds.GithubOAuth != nil {
+		t.Fatalf("expected oauth configs to stay nil without credentials")
+	}
+}
+
+func TestLoadStorageConfigDefaultsToStoreConfig(t *testing.T) {
+	base := testConfig(t)
+	t.Setenv("LORE_DATA_DIR", "")
+	t.Setenv("DATABASE_URL", "")
+
+	storageCfg, err := loadStorageConfig(base)
+	if err != nil {
+		t.Fatalf("loadStorageConfig() error = %v", err)
+	}
+
+	if storageCfg.DataDir != base.DataDir {
+		t.Fatalf("DataDir = %q, want %q", storageCfg.DataDir, base.DataDir)
+	}
+	if storageCfg.DatabaseURL != "" {
+		t.Fatalf("DatabaseURL = %q, want empty", storageCfg.DatabaseURL)
+	}
+}
+
+func TestLoadStorageConfigReadsOverridesAndValidatesDatabaseURL(t *testing.T) {
+	base := testConfig(t)
+	overrideDir := t.TempDir()
+
+	t.Setenv("LORE_DATA_DIR", overrideDir)
+	t.Setenv("DATABASE_URL", "postgres://lore:secret@db.internal:5432/lore")
+
+	storageCfg, err := loadStorageConfig(base)
+	if err != nil {
+		t.Fatalf("loadStorageConfig() error = %v", err)
+	}
+
+	if storageCfg.DataDir != overrideDir {
+		t.Fatalf("DataDir = %q, want %q", storageCfg.DataDir, overrideDir)
+	}
+	if storageCfg.DatabaseURL != "postgres://lore:secret@db.internal:5432/lore" {
+		t.Fatalf("DatabaseURL = %q, want original URL", storageCfg.DatabaseURL)
+	}
+
+	applied := storageCfg.Apply(base)
+	if applied.DataDir != overrideDir {
+		t.Fatalf("applied DataDir = %q, want %q", applied.DataDir, overrideDir)
+	}
+	if applied.DatabaseURL != storageCfg.DatabaseURL {
+		t.Fatalf("applied DatabaseURL = %q, want %q", applied.DatabaseURL, storageCfg.DatabaseURL)
+	}
+}
+
+func TestLoadStorageConfigAcceptsPathBasedDatabaseURL(t *testing.T) {
+	base := testConfig(t)
+	t.Setenv("DATABASE_URL", "sqlite:///tmp/lore.db")
+
+	storageCfg, err := loadStorageConfig(base)
+	if err != nil {
+		t.Fatalf("loadStorageConfig() error = %v", err)
+	}
+	if storageCfg.DatabaseURL != "sqlite:///tmp/lore.db" {
+		t.Fatalf("DatabaseURL = %q, want sqlite:///tmp/lore.db", storageCfg.DatabaseURL)
+	}
+}
+
+func TestLoadStorageConfigRejectsMalformedDatabaseURL(t *testing.T) {
+	base := testConfig(t)
+	t.Setenv("DATABASE_URL", "localhost:5432/lore")
+
+	_, err := loadStorageConfig(base)
+	if err == nil {
+		t.Fatalf("expected DATABASE_URL validation error")
+	}
+	if !strings.Contains(err.Error(), "DATABASE_URL") {
+		t.Fatalf("expected DATABASE_URL mention in error, got %v", err)
 	}
 }
 
@@ -253,6 +391,75 @@ func TestCmdServeStagingMissingJWTSecretFailsFast(t *testing.T) {
 	}
 	if storeCalled {
 		t.Fatalf("expected fail-fast before store initialization")
+	}
+}
+
+func TestCmdServeInvalidDatabaseURLFailsFastBeforeStoreInit(t *testing.T) {
+	cfg := testConfig(t)
+	stubRuntimeHooks(t)
+	stubExitWithPanic(t)
+
+	t.Setenv("LORE_ENV", "local")
+	t.Setenv("DATABASE_URL", "postgres://")
+	withArgs(t, "lore", "serve")
+
+	storeCalled := false
+	storeNew = func(store.Config) (*store.Store, error) {
+		storeCalled = true
+		return nil, nil
+	}
+
+	_, stderr, recovered := captureOutputAndRecover(t, func() { cmdServe(cfg) })
+
+	if _, ok := recovered.(exitCode); !ok {
+		t.Fatalf("expected fatal exit, got %v", recovered)
+	}
+	if !strings.Contains(stderr, "DATABASE_URL") {
+		t.Fatalf("expected DATABASE_URL config error, got %q", stderr)
+	}
+	if storeCalled {
+		t.Fatalf("expected fail-fast before store initialization")
+	}
+}
+
+func TestCmdServeValidDatabaseURLDoesNotEnablePostgresPath(t *testing.T) {
+	cfg := testConfig(t)
+	stubRuntimeHooks(t)
+	storageDir := t.TempDir()
+
+	t.Setenv("LORE_ENV", "local")
+	t.Setenv("LORE_HOST", "127.0.0.1")
+	t.Setenv("PORT", "7555")
+	t.Setenv("LORE_DATA_DIR", storageDir)
+	t.Setenv("DATABASE_URL", "postgres://lore:secret@db.internal:5432/lore")
+	withArgs(t, "lore", "serve")
+
+	seenDatabaseURL := ""
+	seenDataDir := ""
+	seenPort := 0
+	storeNew = func(in store.Config) (*store.Store, error) {
+		seenDatabaseURL = in.DatabaseURL
+		seenDataDir = in.DataDir
+		return store.New(in)
+	}
+	newHTTPServer = func(s *store.Store, cfg server.Config) *server.Server {
+		seenPort = cfg.Port
+		return server.NewWithConfig(s, cfg)
+	}
+	startHTTP = func(_ *server.Server) error { return nil }
+
+	_, stderr, recovered := captureOutputAndRecover(t, func() { cmdServe(cfg) })
+	if recovered != nil {
+		t.Fatalf("expected successful startup, got panic=%v stderr=%q", recovered, stderr)
+	}
+	if seenDatabaseURL == "" {
+		t.Fatalf("expected store config to retain DATABASE_URL")
+	}
+	if seenDataDir != storageDir {
+		t.Fatalf("expected storage config DataDir %q, got %q", storageDir, seenDataDir)
+	}
+	if seenPort != 7555 {
+		t.Fatalf("expected runtime port 7555 from PORT fallback, got %d", seenPort)
 	}
 }
 

--- a/cmd/lore/runtime_config.go
+++ b/cmd/lore/runtime_config.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
-	"github.com/alferio94/lore/internal/store"
 )
 
 type RuntimeEnv string
@@ -24,7 +22,6 @@ type RuntimeConfig struct {
 	BaseURL      string
 	JWTSecret    string
 	CookieSecure bool
-	DataDir      string
 
 	GoogleClientID     string
 	GoogleClientSecret string
@@ -32,7 +29,7 @@ type RuntimeConfig struct {
 	GitHubClientSecret string
 }
 
-func loadRuntimeConfig(cfg store.Config, args []string) (RuntimeConfig, error) {
+func loadRuntimeConfig(args []string) (RuntimeConfig, error) {
 	envRaw := strings.TrimSpace(os.Getenv("LORE_ENV"))
 	env := RuntimeEnvLocal
 	switch envRaw {
@@ -44,20 +41,7 @@ func loadRuntimeConfig(cfg store.Config, args []string) (RuntimeConfig, error) {
 		return RuntimeConfig{}, fmt.Errorf("lore config: invalid LORE_ENV %q (allowed: local, staging)", envRaw)
 	}
 
-	port := 7437
-	if p := strings.TrimSpace(os.Getenv("LORE_PORT")); p != "" {
-		if n, err := strconv.Atoi(p); err == nil {
-			port = n
-		}
-	}
-	for _, arg := range args {
-		if arg == "--dev-auth" {
-			continue
-		}
-		if n, err := strconv.Atoi(arg); err == nil {
-			port = n
-		}
-	}
+	port := resolveServePort(args)
 
 	host := strings.TrimSpace(os.Getenv("LORE_HOST"))
 	if host == "" {
@@ -90,11 +74,6 @@ func loadRuntimeConfig(cfg store.Config, args []string) (RuntimeConfig, error) {
 		return RuntimeConfig{}, fmt.Errorf("lore config: LORE_JWT_SECRET is required when LORE_ENV=staging")
 	}
 
-	dataDir := cfg.DataDir
-	if dir := strings.TrimSpace(os.Getenv("LORE_DATA_DIR")); dir != "" {
-		dataDir = dir
-	}
-
 	return RuntimeConfig{
 		Env:                env,
 		Host:               host,
@@ -102,10 +81,51 @@ func loadRuntimeConfig(cfg store.Config, args []string) (RuntimeConfig, error) {
 		BaseURL:            baseURL,
 		JWTSecret:          jwtSecret,
 		CookieSecure:       cookieSecure,
-		DataDir:            dataDir,
 		GoogleClientID:     os.Getenv("LORE_GOOGLE_CLIENT_ID"),
 		GoogleClientSecret: os.Getenv("LORE_GOOGLE_CLIENT_SECRET"),
 		GitHubClientID:     os.Getenv("LORE_GITHUB_CLIENT_ID"),
 		GitHubClientSecret: os.Getenv("LORE_GITHUB_CLIENT_SECRET"),
 	}, nil
+}
+
+func resolveServePort(args []string) int {
+	if argPort, ok := parsePositionalPortArg(args); ok {
+		return argPort
+	}
+
+	if lorePort, ok := parsePortEnv("LORE_PORT"); ok {
+		return lorePort
+	}
+
+	if port, ok := parsePortEnv("PORT"); ok {
+		return port
+	}
+
+	return 7437
+}
+
+func parsePositionalPortArg(args []string) (int, bool) {
+	for _, arg := range args {
+		if arg == "--dev-auth" {
+			continue
+		}
+		n, err := strconv.Atoi(arg)
+		if err != nil {
+			continue
+		}
+		return n, true
+	}
+	return 0, false
+}
+
+func parsePortEnv(key string) (int, bool) {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }

--- a/cmd/lore/storage_config.go
+++ b/cmd/lore/storage_config.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/alferio94/lore/internal/store"
+)
+
+type StorageConfig struct {
+	DataDir     string
+	DatabaseURL string
+}
+
+func loadStorageConfig(base store.Config) (StorageConfig, error) {
+	storageCfg := StorageConfig{
+		DataDir: strings.TrimSpace(base.DataDir),
+	}
+
+	if dataDir := strings.TrimSpace(os.Getenv("LORE_DATA_DIR")); dataDir != "" {
+		storageCfg.DataDir = dataDir
+	}
+
+	databaseURL := strings.TrimSpace(os.Getenv("DATABASE_URL"))
+	if databaseURL != "" {
+		if err := validateDatabaseURL(databaseURL); err != nil {
+			return StorageConfig{}, err
+		}
+		storageCfg.DatabaseURL = databaseURL
+	}
+
+	return storageCfg, nil
+}
+
+func validateDatabaseURL(raw string) error {
+	if !strings.Contains(raw, "://") {
+		return fmt.Errorf("lore config: invalid DATABASE_URL %q: expected URI scheme separator (://)", raw)
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("lore config: invalid DATABASE_URL %q: %w", raw, err)
+	}
+	if parsed.Scheme == "" {
+		return fmt.Errorf("lore config: invalid DATABASE_URL %q: missing URL scheme", raw)
+	}
+	if parsed.Host == "" && parsed.Opaque == "" && strings.TrimSpace(parsed.Path) == "" {
+		return fmt.Errorf("lore config: invalid DATABASE_URL %q: missing URL authority/path", raw)
+	}
+	return nil
+}
+
+func (cfg StorageConfig) Apply(base store.Config) store.Config {
+	base.DataDir = cfg.DataDir
+	base.DatabaseURL = cfg.DatabaseURL
+	return base
+}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - "7437:7437"
     volumes:
+      # Docker deployment path: persist local SQLite files on this volume.
       # SQLite WAL mode creates lore.db, lore.db-wal, and lore.db-shm.
       # All three files must live on the same persistent volume (LORE_DATA_DIR).
       # Removing this volume mount risks apparent data loss on container restart.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -140,7 +140,11 @@ The binary includes SQLite (via [modernc.org/sqlite](https://pkg.go.dev/modernc.
 | Variable | Description | Default |
 |---|---|---|
 | `LORE_DATA_DIR` | Data directory | `~/.lore` (Windows: `%USERPROFILE%\.lore`) |
-| `LORE_PORT` | HTTP server port | `7437` |
+| `LORE_PORT` | Preferred HTTP server port for `lore serve` (highest env precedence) | `7437` |
+| `PORT` | Cloud-host fallback port when `LORE_PORT` is unset | unset |
+| `DATABASE_URL` | Forward-compatible external DB URL (syntax validation only; SQLite remains active) | unset |
+
+Port precedence in `lore serve`: positional argument (`lore serve 9090`) → `LORE_PORT` → `PORT` → `7437`.
 
 ---
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -346,6 +346,7 @@ type ExportData struct {
 
 type Config struct {
 	DataDir              string
+	DatabaseURL          string
 	MaxObservationLength int
 	MaxContextResults    int
 	MaxSearchResults     int
@@ -359,6 +360,7 @@ func DefaultConfig() (Config, error) {
 	}
 	return Config{
 		DataDir:              filepath.Join(home, ".lore"),
+		DatabaseURL:          "",
 		MaxObservationLength: 50000,
 		MaxContextResults:    20,
 		MaxSearchResults:     20,
@@ -372,6 +374,7 @@ func DefaultConfig() (Config, error) {
 func FallbackConfig(dataDir string) Config {
 	return Config{
 		DataDir:              dataDir,
+		DatabaseURL:          "",
 		MaxObservationLength: 50000,
 		MaxContextResults:    20,
 		MaxSearchResults:     20,

--- a/scripts/validate-staging.sh
+++ b/scripts/validate-staging.sh
@@ -26,7 +26,7 @@ fi
 
 if ! command -v docker >/dev/null 2>&1; then
   printf '%s\n' "WARN: docker binary not found; skipping compose validation." >&2
-  printf '%s\n' "Staging artifact checks passed (compose syntax not validated)."
+  printf '%s\n' "Runtime/deployment artifact checks passed (compose syntax not validated)."
   exit 0
 fi
 
@@ -51,4 +51,4 @@ if ! docker compose -f "$COMPOSE_FILE" config --quiet; then
   fail "docker compose config validation failed for docker-compose.staging.yml"
 fi
 
-printf '%s\n' "Staging artifact checks passed."
+printf '%s\n' "Runtime/deployment artifact checks passed."


### PR DESCRIPTION
Closes #8

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- separate `serve` runtime config from storage config with a new `StorageConfig` loader
- add hosted-runtime port precedence (`arg > LORE_PORT > PORT > 7437`) and forward-compatible `DATABASE_URL` validation
- update tests, docs, env examples, and deployment checks while keeping SQLite as the active backend

## Changes
| File | Change |
|------|--------|
| `cmd/lore/storage_config.go` | Add storage config loader and `DATABASE_URL` validation |
| `cmd/lore/runtime_config.go` | Limit runtime config to runtime-only fields and add explicit port resolution helpers |
| `cmd/lore/main.go` | Wire `serve` startup through separate runtime and storage config paths |
| `internal/store/store.go` | Add forward-compatible `DatabaseURL` field to store config without activating PostgreSQL |
| `cmd/lore/main_test.go` | Add storage-config and serve wiring regression coverage |
| `cmd/lore/main_extra_test.go` | Expand port precedence coverage for `LORE_PORT`, `PORT`, and arg overrides |
| `cmd/lore/docker_staging_test.go` | Update runtime/deployment artifact assertions |
| `.env.example` | Document `PORT` fallback and `DATABASE_URL` acceptance |
| `docs/INSTALLATION.md` | Document hosted runtime contract and port precedence |
| `DOCS.md` | Align CLI/env/runtime docs with current behavior |
| `scripts/validate-staging.sh` | Reword validation output around runtime/deployment artifacts |
| `.github/workflows/ci.yml` | Rename validation steps to reflect runtime/deployment scope |
| `docker-compose.staging.yml` | Clarify Docker volume as a Docker deployment path for SQLite |

## Test Plan
- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran unit tests locally
- [x] Ran e2e tests locally
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers