### PR TITLE
feat(store): add postgresql backend bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,8 +24,9 @@ LORE_COOKIE_SECURE=true
 # WAL mode also writes lore.db-wal and lore.db-shm in this same directory.
 LORE_DATA_DIR=/data
 
-# Forward-compatible external DB URL (syntax-validated only in this phase).
-# Lore still uses local SQLite as the active backend.
+# PostgreSQL runtime selector. Only postgres:// and postgresql:// switch the
+# backend; other URLs keep SQLite as the default local backend.
+# Search parity, containerized app runtime, and deployment changes are out of scope.
 DATABASE_URL=
 
 # Google OAuth (optional — admin login)

--- a/DOCS.md
+++ b/DOCS.md
@@ -112,8 +112,17 @@ lore help               Show help
 | `LORE_DATA_DIR` | Override data directory | `~/.lore` |
 | `LORE_PORT` | Preferred HTTP server port for `lore serve` | `7437` |
 | `PORT` | Cloud-host fallback port when `LORE_PORT` is unset | unset |
-| `DATABASE_URL` | Forward-compatible storage input (syntax-validated only; SQLite stays active) | unset |
+| `DATABASE_URL` | `postgres://` / `postgresql://` selects PostgreSQL; other URLs keep SQLite default | unset |
 | `LORE_PROJECT` | Override project name for MCP server | auto-detected via git |
+
+Selection rules:
+
+- unset `DATABASE_URL` → SQLite remains active
+- PostgreSQL URL → PostgreSQL backend bootstrap slice (health, sessions, core observations, sync journal)
+- non-PostgreSQL URL → SQLite remains active
+- malformed URL → startup fails before store initialization
+
+Local PostgreSQL validation uses `docker-compose.postgres.yml` plus `scripts/validate-postgres-local.sh` to run PostgreSQL in Docker while the Go app runs on the host. Search parity, full containerization, and deployment changes remain out of scope.
 
 ---
 

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -119,6 +119,14 @@ var (
 	newObsidianWatcher = obsidian.NewWatcher
 )
 
+func openConfiguredStore(cfg store.Config) (store.Contract, error) {
+	storageCfg, err := loadStorageConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return storeOpen(storageCfg.Apply(cfg))
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		printUsage()
@@ -201,13 +209,6 @@ func cmdServe(cfg store.Config) {
 		fatal(err)
 	}
 
-	storageCfg, err := loadStorageConfig(cfg)
-	if err != nil {
-		fatal(err)
-	}
-
-	cfg = storageCfg.Apply(cfg)
-
 	// Allow: lore serve --dev-auth
 	devAuth := false
 	for i := 2; i < len(os.Args); i++ {
@@ -216,7 +217,7 @@ func cmdServe(cfg store.Config) {
 		}
 	}
 
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -328,7 +329,7 @@ func cmdMCP(cfg store.Config) {
 	// Always normalize (lowercase + trim)
 	detectedProject, _ = store.NormalizeProject(detectedProject)
 
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -347,7 +348,7 @@ func cmdMCP(cfg store.Config) {
 }
 
 func cmdTUI(cfg store.Config) {
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -405,7 +406,7 @@ func cmdSearch(cfg store.Config) {
 		exitFunc(1)
 	}
 
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 		return
@@ -474,7 +475,7 @@ func cmdSave(cfg store.Config) {
 		}
 	}
 
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -533,7 +534,7 @@ func cmdTimeline(cfg store.Config) {
 		}
 	}
 
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -595,7 +596,7 @@ func cmdContext(cfg store.Config) {
 		}
 	}
 
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -615,7 +616,7 @@ func cmdContext(cfg store.Config) {
 }
 
 func cmdStats(cfg store.Config) {
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -645,7 +646,7 @@ func cmdExport(cfg store.Config) {
 		outFile = os.Args[2]
 	}
 
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -688,7 +689,7 @@ func cmdImport(cfg store.Config) {
 		fatal(fmt.Errorf("parse %s: %w", inFile, err))
 	}
 
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -738,7 +739,7 @@ func cmdSync(cfg store.Config) {
 
 	syncDir := ".lore"
 
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -945,7 +946,7 @@ func cmdObsidianExport(cfg store.Config) {
 		exportCfg.Since = sinceTime
 	}
 
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -1016,7 +1017,7 @@ func cmdProjects(cfg store.Config) {
 }
 
 func cmdProjectsList(cfg store.Config) {
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -1167,7 +1168,7 @@ func cmdProjectsConsolidate(cfg store.Config) {
 		}
 	}
 
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -1423,7 +1424,7 @@ func cmdProjectsPrune(cfg store.Config) {
 		}
 	}
 
-	s, err := storeOpen(cfg)
+	s, err := openConfiguredStore(cfg)
 	if err != nil {
 		fatal(err)
 	}
@@ -1646,7 +1647,7 @@ Environment:
   LORE_DATA_DIR    Override SQLite data directory (default: ~/.lore)
   LORE_PORT        Preferred HTTP server port for serve (default: 7437)
   PORT             Cloud runtime fallback port when LORE_PORT is unset
-  DATABASE_URL     Forward-compatible storage URL (syntax-validated only; SQLite remains active)
+  DATABASE_URL     Storage URL; postgres:// selects PostgreSQL, others keep SQLite default
   LORE_PROJECT     Override auto-detected project name for MCP server
 
 MCP Configuration (add to your agent's config):

--- a/cmd/lore/main_extra_test.go
+++ b/cmd/lore/main_extra_test.go
@@ -1055,7 +1055,10 @@ func TestCmdServeRuntimeContractIntegrationLike(t *testing.T) {
 	storeOpen = func(in store.Config) (store.Contract, error) {
 		seenStoreDataDir = in.DataDir
 		seenStoreDatabaseURL = in.DatabaseURL
-		return store.New(in)
+		if in.SelectedBackend() != store.BackendPostgreSQL {
+			t.Fatalf("SelectedBackend() = %q, want %q", in.SelectedBackend(), store.BackendPostgreSQL)
+		}
+		return noopStore{}, nil
 	}
 	newHTTPServer = func(s store.Contract, cfg engramsrv.Config) *engramsrv.Server {
 		seenServerHost = cfg.Host

--- a/cmd/lore/main_test.go
+++ b/cmd/lore/main_test.go
@@ -52,6 +52,10 @@ func withCwd(t *testing.T, dir string) {
 	})
 }
 
+type noopStore struct{ store.Contract }
+
+func (noopStore) Close() error { return nil }
+
 func stubCheckForUpdates(t *testing.T, result versioncheck.CheckResult) {
 	t.Helper()
 	old := checkForUpdates
@@ -309,6 +313,9 @@ func TestLoadStorageConfigDefaultsToStoreConfig(t *testing.T) {
 	if storageCfg.DatabaseURL != "" {
 		t.Fatalf("DatabaseURL = %q, want empty", storageCfg.DatabaseURL)
 	}
+	if storageCfg.Backend != store.BackendSQLite {
+		t.Fatalf("Backend = %q, want %q", storageCfg.Backend, store.BackendSQLite)
+	}
 }
 
 func TestLoadStorageConfigReadsOverridesAndValidatesDatabaseURL(t *testing.T) {
@@ -329,6 +336,9 @@ func TestLoadStorageConfigReadsOverridesAndValidatesDatabaseURL(t *testing.T) {
 	if storageCfg.DatabaseURL != "postgres://lore:secret@db.internal:5432/lore" {
 		t.Fatalf("DatabaseURL = %q, want original URL", storageCfg.DatabaseURL)
 	}
+	if storageCfg.Backend != store.BackendPostgreSQL {
+		t.Fatalf("Backend = %q, want %q", storageCfg.Backend, store.BackendPostgreSQL)
+	}
 
 	applied := storageCfg.Apply(base)
 	if applied.DataDir != overrideDir {
@@ -336,6 +346,9 @@ func TestLoadStorageConfigReadsOverridesAndValidatesDatabaseURL(t *testing.T) {
 	}
 	if applied.DatabaseURL != storageCfg.DatabaseURL {
 		t.Fatalf("applied DatabaseURL = %q, want %q", applied.DatabaseURL, storageCfg.DatabaseURL)
+	}
+	if applied.SelectedBackend() != store.BackendPostgreSQL {
+		t.Fatalf("applied SelectedBackend() = %q, want %q", applied.SelectedBackend(), store.BackendPostgreSQL)
 	}
 }
 
@@ -349,6 +362,9 @@ func TestLoadStorageConfigAcceptsPathBasedDatabaseURL(t *testing.T) {
 	}
 	if storageCfg.DatabaseURL != "sqlite:///tmp/lore.db" {
 		t.Fatalf("DatabaseURL = %q, want sqlite:///tmp/lore.db", storageCfg.DatabaseURL)
+	}
+	if storageCfg.Backend != store.BackendSQLite {
+		t.Fatalf("Backend = %q, want %q", storageCfg.Backend, store.BackendSQLite)
 	}
 }
 
@@ -422,7 +438,7 @@ func TestCmdServeInvalidDatabaseURLFailsFastBeforeStoreInit(t *testing.T) {
 	}
 }
 
-func TestCmdServeValidDatabaseURLDoesNotEnablePostgresPath(t *testing.T) {
+func TestCmdServeValidPostgresDatabaseURLEnablesPostgresPath(t *testing.T) {
 	cfg := testConfig(t)
 	stubRuntimeHooks(t)
 	storageDir := t.TempDir()
@@ -440,10 +456,10 @@ func TestCmdServeValidDatabaseURLDoesNotEnablePostgresPath(t *testing.T) {
 	storeOpen = func(in store.Config) (store.Contract, error) {
 		seenDatabaseURL = in.DatabaseURL
 		seenDataDir = in.DataDir
-		if in.SelectedBackend() != store.BackendSQLite {
-			t.Fatalf("SelectedBackend() = %q, want %q", in.SelectedBackend(), store.BackendSQLite)
+		if in.SelectedBackend() != store.BackendPostgreSQL {
+			t.Fatalf("SelectedBackend() = %q, want %q", in.SelectedBackend(), store.BackendPostgreSQL)
 		}
-		return store.New(in)
+		return noopStore{}, nil
 	}
 	newHTTPServer = func(s store.Contract, cfg server.Config) *server.Server {
 		seenPort = cfg.Port
@@ -463,6 +479,58 @@ func TestCmdServeValidDatabaseURLDoesNotEnablePostgresPath(t *testing.T) {
 	}
 	if seenPort != 7555 {
 		t.Fatalf("expected runtime port 7555 from PORT fallback, got %d", seenPort)
+	}
+}
+
+func TestCmdMCPUsesDatabaseURLStorageConfig(t *testing.T) {
+	cfg := testConfig(t)
+	stubRuntimeHooks(t)
+	stubExitWithPanic(t)
+
+	t.Setenv("DATABASE_URL", "postgres://lore:secret@db.internal:5432/lore")
+	withArgs(t, "lore", "mcp")
+
+	seenDatabaseURL := ""
+	storeOpen = func(in store.Config) (store.Contract, error) {
+		seenDatabaseURL = in.DatabaseURL
+		if in.SelectedBackend() != store.BackendPostgreSQL {
+			t.Fatalf("SelectedBackend() = %q, want %q", in.SelectedBackend(), store.BackendPostgreSQL)
+		}
+		return noopStore{}, nil
+	}
+
+	_, stderr, recovered := captureOutputAndRecover(t, func() { cmdMCP(cfg) })
+	if recovered != nil {
+		t.Fatalf("expected successful mcp startup, got panic=%v stderr=%q", recovered, stderr)
+	}
+	if seenDatabaseURL == "" {
+		t.Fatalf("expected store config to retain DATABASE_URL")
+	}
+}
+
+func TestCmdMCPInvalidDatabaseURLFailsFastBeforeStoreInit(t *testing.T) {
+	cfg := testConfig(t)
+	stubRuntimeHooks(t)
+	stubExitWithPanic(t)
+
+	t.Setenv("DATABASE_URL", "postgres://")
+	withArgs(t, "lore", "mcp")
+
+	storeCalled := false
+	storeOpen = func(store.Config) (store.Contract, error) {
+		storeCalled = true
+		return nil, nil
+	}
+
+	_, stderr, recovered := captureOutputAndRecover(t, func() { cmdMCP(cfg) })
+	if _, ok := recovered.(exitCode); !ok {
+		t.Fatalf("expected fatal exit, got %v", recovered)
+	}
+	if !strings.Contains(stderr, "DATABASE_URL") {
+		t.Fatalf("expected DATABASE_URL config error, got %q", stderr)
+	}
+	if storeCalled {
+		t.Fatalf("expected fail-fast before store initialization")
 	}
 }
 

--- a/cmd/lore/storage_config.go
+++ b/cmd/lore/storage_config.go
@@ -12,11 +12,13 @@ import (
 type StorageConfig struct {
 	DataDir     string
 	DatabaseURL string
+	Backend     store.Backend
 }
 
 func loadStorageConfig(base store.Config) (StorageConfig, error) {
 	storageCfg := StorageConfig{
 		DataDir: strings.TrimSpace(base.DataDir),
+		Backend: base.SelectedBackend(),
 	}
 
 	if dataDir := strings.TrimSpace(os.Getenv("LORE_DATA_DIR")); dataDir != "" {
@@ -25,35 +27,57 @@ func loadStorageConfig(base store.Config) (StorageConfig, error) {
 
 	databaseURL := strings.TrimSpace(os.Getenv("DATABASE_URL"))
 	if databaseURL != "" {
-		if err := validateDatabaseURL(databaseURL); err != nil {
+		parsed, err := validateDatabaseURL(databaseURL)
+		if err != nil {
 			return StorageConfig{}, err
 		}
 		storageCfg.DatabaseURL = databaseURL
+		if isPostgresScheme(parsed.Scheme) {
+			storageCfg.Backend = store.BackendPostgreSQL
+		}
 	}
 
 	return storageCfg, nil
 }
 
-func validateDatabaseURL(raw string) error {
+func validateDatabaseURL(raw string) (*url.URL, error) {
 	if !strings.Contains(raw, "://") {
-		return fmt.Errorf("lore config: invalid DATABASE_URL %q: expected URI scheme separator (://)", raw)
+		return nil, fmt.Errorf("lore config: invalid DATABASE_URL %q: expected URI scheme separator (://)", raw)
 	}
 
 	parsed, err := url.Parse(raw)
 	if err != nil {
-		return fmt.Errorf("lore config: invalid DATABASE_URL %q: %w", raw, err)
+		return nil, fmt.Errorf("lore config: invalid DATABASE_URL %q: %w", raw, err)
 	}
 	if parsed.Scheme == "" {
-		return fmt.Errorf("lore config: invalid DATABASE_URL %q: missing URL scheme", raw)
+		return nil, fmt.Errorf("lore config: invalid DATABASE_URL %q: missing URL scheme", raw)
 	}
 	if parsed.Host == "" && parsed.Opaque == "" && strings.TrimSpace(parsed.Path) == "" {
-		return fmt.Errorf("lore config: invalid DATABASE_URL %q: missing URL authority/path", raw)
+		return nil, fmt.Errorf("lore config: invalid DATABASE_URL %q: missing URL authority/path", raw)
 	}
-	return nil
+	if isPostgresScheme(parsed.Scheme) {
+		if parsed.Host == "" {
+			return nil, fmt.Errorf("lore config: invalid DATABASE_URL %q: missing PostgreSQL host", raw)
+		}
+		if strings.Trim(parsed.Path, "/") == "" {
+			return nil, fmt.Errorf("lore config: invalid DATABASE_URL %q: missing PostgreSQL database name", raw)
+		}
+	}
+	return parsed, nil
 }
 
 func (cfg StorageConfig) Apply(base store.Config) store.Config {
 	base.DataDir = cfg.DataDir
 	base.DatabaseURL = cfg.DatabaseURL
+	base.Backend = cfg.Backend
 	return base
+}
+
+func isPostgresScheme(scheme string) bool {
+	switch strings.ToLower(strings.TrimSpace(scheme)) {
+	case "postgres", "postgresql":
+		return true
+	default:
+		return false
+	}
 }

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,20 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: lore-postgres-local
+    environment:
+      POSTGRES_USER: lore
+      POSTGRES_PASSWORD: lore
+      POSTGRES_DB: lore
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U lore -d lore"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    volumes:
+      - lore-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  lore-postgres-data:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -142,9 +142,27 @@ The binary includes SQLite (via [modernc.org/sqlite](https://pkg.go.dev/modernc.
 | `LORE_DATA_DIR` | Data directory | `~/.lore` (Windows: `%USERPROFILE%\.lore`) |
 | `LORE_PORT` | Preferred HTTP server port for `lore serve` (highest env precedence) | `7437` |
 | `PORT` | Cloud-host fallback port when `LORE_PORT` is unset | unset |
-| `DATABASE_URL` | Forward-compatible external DB URL (syntax validation only; SQLite remains active) | unset |
+| `DATABASE_URL` | `postgres://` / `postgresql://` selects PostgreSQL; other URLs keep SQLite as default | unset |
 
 Port precedence in `lore serve`: positional argument (`lore serve 9090`) → `LORE_PORT` → `PORT` → `7437`.
+
+Backend selection in `lore serve`:
+
+- unset `DATABASE_URL` → SQLite
+- `postgres://...` or `postgresql://...` → PostgreSQL
+- any other valid URL (for example `sqlite:///tmp/lore.db`) → SQLite
+- malformed `DATABASE_URL` → startup fails before store initialization
+
+## Local PostgreSQL validation
+
+This repo includes a host-app validation path for the first PostgreSQL slice:
+
+```bash
+docker compose -f docker-compose.postgres.yml up -d postgres
+scripts/validate-postgres-local.sh
+```
+
+The script starts only PostgreSQL in Docker and runs the Go app locally against it. It verifies `/health`, session create/end, and core observation CRUD. Search parity, full app containerization, and deployment wiring remain out of scope for this change.
 
 ---
 

--- a/internal/server/server_e2e_test.go
+++ b/internal/server/server_e2e_test.go
@@ -5,14 +5,18 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/alferio94/lore/internal/store"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
 )
 
 func newE2EServer(t *testing.T) (*store.Store, *httptest.Server) {
@@ -35,6 +39,64 @@ func newE2EServer(t *testing.T) (*store.Store, *httptest.Server) {
 	})
 
 	return s, httpServer
+}
+
+func newPostgresE2EServer(t *testing.T) (*store.PostgresStore, *httptest.Server) {
+	t.Helper()
+
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		t.Skipf("docker unavailable: %v", err)
+	}
+
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: "postgres",
+		Tag:        "16-alpine",
+		Env: []string{
+			"POSTGRES_USER=lore",
+			"POSTGRES_PASSWORD=lore",
+			"POSTGRES_DB=lore",
+		},
+	}, func(config *docker.HostConfig) {
+		config.AutoRemove = true
+		config.RestartPolicy = docker.RestartPolicy{Name: "no"}
+	})
+	if err != nil {
+		t.Skipf("postgres container unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = pool.Purge(resource) })
+
+	databaseURL := fmt.Sprintf("postgres://lore:lore@127.0.0.1:%s/lore?sslmode=disable", resource.GetPort("5432/tcp"))
+
+	var opened store.Contract
+	err = pool.Retry(func() error {
+		opened, err = store.Open(store.Config{
+			Backend:              store.BackendPostgreSQL,
+			DatabaseURL:          databaseURL,
+			MaxObservationLength: 50000,
+			MaxContextResults:    20,
+			MaxSearchResults:     20,
+			DedupeWindow:         15 * time.Minute,
+		})
+		return err
+	})
+	if err != nil {
+		t.Skipf("postgres did not become ready: %v", err)
+	}
+
+	pg, ok := opened.(*store.PostgresStore)
+	if !ok {
+		_ = opened.Close()
+		t.Fatalf("Open() returned %T, want *store.PostgresStore", opened)
+	}
+
+	httpServer := httptest.NewServer(New(pg, 0).Handler())
+	t.Cleanup(func() {
+		httpServer.Close()
+		_ = pg.Close()
+	})
+
+	return pg, httpServer
 }
 
 func postJSON(t *testing.T, client *http.Client, url string, body any) *http.Response {
@@ -269,6 +331,115 @@ func TestPassiveCaptureEndpointE2E(t *testing.T) {
 	if len(results) != 1 {
 		t.Fatalf("expected 1 search result, got %d", len(results))
 	}
+}
+
+func TestPostgresApprovedSliceE2E(t *testing.T) {
+	_, ts := newPostgresE2EServer(t)
+	client := ts.Client()
+
+	healthResp, err := client.Get(ts.URL + "/health")
+	if err != nil {
+		t.Fatalf("health: %v", err)
+	}
+	if healthResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 health, got %d", healthResp.StatusCode)
+	}
+	_ = healthResp.Body.Close()
+
+	sessionResp := postJSON(t, client, ts.URL+"/sessions", map[string]any{
+		"id":        "pg-e2e",
+		"project":   "lore",
+		"directory": "/tmp/lore",
+	})
+	if sessionResp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 creating session, got %d", sessionResp.StatusCode)
+	}
+	_ = sessionResp.Body.Close()
+
+	createResp := postJSON(t, client, ts.URL+"/observations", map[string]any{
+		"session_id": "pg-e2e",
+		"type":       "architecture",
+		"title":      "Postgres slice",
+		"content":    "Keep local sqlite default and postgres additive",
+		"project":    "lore",
+		"scope":      "project",
+		"topic_key":  "architecture/postgres-slice",
+	})
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 creating observation, got %d", createResp.StatusCode)
+	}
+	body := decodeJSON[map[string]any](t, createResp)
+	id := int64(body["id"].(float64))
+
+	updateReq, err := http.NewRequest(http.MethodPatch, ts.URL+"/observations/"+strconv.FormatInt(id, 10), strings.NewReader(`{"content":"Keep local sqlite default, postgres additive, and sync scoped"}`))
+	if err != nil {
+		t.Fatalf("new patch request: %v", err)
+	}
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateResp, err := client.Do(updateReq)
+	if err != nil {
+		t.Fatalf("patch observation: %v", err)
+	}
+	if updateResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 patching observation, got %d", updateResp.StatusCode)
+	}
+	_ = updateResp.Body.Close()
+
+	getResp, err := client.Get(ts.URL + "/observations/" + strconv.FormatInt(id, 10))
+	if err != nil {
+		t.Fatalf("get observation: %v", err)
+	}
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 getting observation, got %d", getResp.StatusCode)
+	}
+	obs := decodeJSON[map[string]any](t, getResp)
+	if !strings.Contains(obs["content"].(string), "sync scoped") {
+		t.Fatalf("expected updated content, got %q", obs["content"].(string))
+	}
+
+	timelineResp, err := client.Get(ts.URL + "/timeline?observation_id=" + strconv.FormatInt(id, 10) + "&before=1&after=1")
+	if err != nil {
+		t.Fatalf("timeline: %v", err)
+	}
+	if timelineResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 timeline, got %d", timelineResp.StatusCode)
+	}
+	_ = timelineResp.Body.Close()
+
+	searchResp, err := client.Get(ts.URL + "/search?q=postgres&project=lore&scope=project&limit=10")
+	if err != nil {
+		t.Fatalf("search request: %v", err)
+	}
+	if searchResp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 search unsupported, got %d", searchResp.StatusCode)
+	}
+	searchBody, _ := io.ReadAll(searchResp.Body)
+	_ = searchResp.Body.Close()
+	if !strings.Contains(string(searchBody), "does not support search") {
+		t.Fatalf("expected explicit unsupported search error, got %q", string(searchBody))
+	}
+
+	deleteReq, err := http.NewRequest(http.MethodDelete, ts.URL+"/observations/"+strconv.FormatInt(id, 10), nil)
+	if err != nil {
+		t.Fatalf("new delete request: %v", err)
+	}
+	deleteResp, err := client.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("delete observation: %v", err)
+	}
+	if deleteResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 deleting observation, got %d", deleteResp.StatusCode)
+	}
+	_ = deleteResp.Body.Close()
+
+	missingResp, err := client.Get(ts.URL + "/observations/" + strconv.FormatInt(id, 10))
+	if err != nil {
+		t.Fatalf("get deleted observation: %v", err)
+	}
+	if missingResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 after soft delete, got %d", missingResp.StatusCode)
+	}
+	_ = missingResp.Body.Close()
 }
 
 func TestPassiveCaptureEndpointEmptyContentE2E(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"net"
@@ -172,6 +173,32 @@ func TestHandleHealthReturnsUnavailableWhenStoreIsUnavailable(t *testing.T) {
 	}
 	if body["reason"] != "store unavailable" {
 		t.Fatalf("reason = %v, want store unavailable", body["reason"])
+	}
+}
+
+type healthOnlyContract struct {
+	store.Contract
+	pingErr error
+}
+
+func (h healthOnlyContract) Ping(context.Context) error { return h.pingErr }
+
+func TestHandleHealthUsesBackendNeutralPingContract(t *testing.T) {
+	srv := NewWithConfig(healthOnlyContract{}, Config{Host: "127.0.0.1", Port: 0, Version: "pg-test"})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 from backend-neutral ping contract, got %d", rec.Code)
+	}
+
+	srv = NewWithConfig(healthOnlyContract{pingErr: errors.New("db unavailable")}, Config{Host: "127.0.0.1", Port: 0, Version: "pg-test"})
+	req = httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when ping contract fails, got %d", rec.Code)
 	}
 }
 

--- a/internal/store/backend/postgres/postgres.go
+++ b/internal/store/backend/postgres/postgres.go
@@ -1,0 +1,163 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+var pingDatabase = func(ctx context.Context, db *sql.DB) error {
+	return db.PingContext(ctx)
+}
+
+func OpenDatabase(raw string, open func(driverName, dataSourceName string) (*sql.DB, error)) (*sql.DB, error) {
+	normalized, err := NormalizeDSN(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := open("postgres", normalized)
+	if err != nil {
+		return nil, fmt.Errorf("lore: open postgres database: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := pingDatabase(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("lore: ping postgres database: %w", err)
+	}
+
+	if err := Bootstrap(db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	return db, nil
+}
+
+func NormalizeDSN(raw string) (string, error) {
+	if !strings.Contains(raw, "://") {
+		return "", fmt.Errorf("lore: invalid postgres DATABASE_URL %q: expected URI scheme separator (://)", raw)
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("lore: invalid postgres DATABASE_URL %q: %w", raw, err)
+	}
+	if parsed.Scheme != "postgres" && parsed.Scheme != "postgresql" {
+		return "", fmt.Errorf("lore: invalid postgres DATABASE_URL %q: unsupported scheme %q", raw, parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("lore: invalid postgres DATABASE_URL %q: missing host", raw)
+	}
+	if strings.Trim(parsed.Path, "/") == "" {
+		return "", fmt.Errorf("lore: invalid postgres DATABASE_URL %q: missing database name", raw)
+	}
+
+	query := parsed.Query()
+	if isLocalHost(parsed.Hostname()) && query.Get("sslmode") == "" {
+		query.Set("sslmode", "disable")
+		parsed.RawQuery = query.Encode()
+	}
+
+	return parsed.String(), nil
+}
+
+func Bootstrap(db *sql.DB) error {
+	statements := []string{
+		`CREATE TABLE IF NOT EXISTS sessions (
+			id TEXT PRIMARY KEY,
+			project TEXT NOT NULL,
+			directory TEXT NOT NULL,
+			started_at TEXT NOT NULL DEFAULT to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'),
+			ended_at TEXT,
+			summary TEXT
+		)`,
+		`CREATE TABLE IF NOT EXISTS observations (
+			id BIGSERIAL PRIMARY KEY,
+			sync_id TEXT,
+			session_id TEXT NOT NULL REFERENCES sessions(id),
+			type TEXT NOT NULL,
+			title TEXT NOT NULL,
+			content TEXT NOT NULL,
+			tool_name TEXT,
+			project TEXT,
+			scope TEXT NOT NULL DEFAULT 'project',
+			topic_key TEXT,
+			normalized_hash TEXT,
+			revision_count INTEGER NOT NULL DEFAULT 1,
+			duplicate_count INTEGER NOT NULL DEFAULT 1,
+			last_seen_at TEXT,
+			created_at TEXT NOT NULL DEFAULT to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'),
+			updated_at TEXT NOT NULL DEFAULT to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'),
+			deleted_at TEXT
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_obs_session ON observations(session_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_obs_type ON observations(type)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_obs_project ON observations(project)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_obs_created ON observations(created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_obs_topic_project_scope ON observations(topic_key, project, scope)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_obs_hash_project_scope ON observations(normalized_hash, project, scope)`,
+		`CREATE TABLE IF NOT EXISTS sync_state (
+			target_key TEXT PRIMARY KEY,
+			lifecycle TEXT NOT NULL DEFAULT 'idle',
+			last_enqueued_seq BIGINT NOT NULL DEFAULT 0,
+			last_acked_seq BIGINT NOT NULL DEFAULT 0,
+			last_pulled_seq BIGINT NOT NULL DEFAULT 0,
+			consecutive_failures INTEGER NOT NULL DEFAULT 0,
+			backoff_until TEXT,
+			lease_owner TEXT,
+			lease_until TEXT,
+			last_error TEXT,
+			updated_at TEXT NOT NULL DEFAULT to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS')
+		)`,
+		`CREATE TABLE IF NOT EXISTS sync_mutations (
+			seq BIGSERIAL PRIMARY KEY,
+			target_key TEXT NOT NULL REFERENCES sync_state(target_key),
+			entity TEXT NOT NULL,
+			entity_key TEXT NOT NULL,
+			op TEXT NOT NULL,
+			payload TEXT NOT NULL,
+			source TEXT NOT NULL DEFAULT 'local',
+			project TEXT NOT NULL DEFAULT '',
+			occurred_at TEXT NOT NULL DEFAULT to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'),
+			acked_at TEXT
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_sync_mutations_target_seq ON sync_mutations(target_key, seq)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_sync_mutations_project ON sync_mutations(project)`,
+	}
+
+	for _, statement := range statements {
+		if _, err := db.Exec(statement); err != nil {
+			return fmt.Errorf("lore: bootstrap postgres schema: %w", err)
+		}
+	}
+
+	if _, err := db.Exec(`
+		INSERT INTO sync_state (target_key, lifecycle, updated_at)
+		VALUES ($1, $2, to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'))
+		ON CONFLICT (target_key) DO NOTHING
+	`, "cloud", "idle"); err != nil {
+		return fmt.Errorf("lore: bootstrap postgres sync_state seed: %w", err)
+	}
+
+	return nil
+}
+
+func isLocalHost(host string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" || host == "localhost" || host == "127.0.0.1" || host == "::1" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}

--- a/internal/store/backend/postgres/postgres_test.go
+++ b/internal/store/backend/postgres/postgres_test.go
@@ -1,0 +1,168 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestNormalizeDSNRejectsMissingDatabaseName(t *testing.T) {
+	_, err := NormalizeDSN("postgres://lore:secret@127.0.0.1:5432")
+	if err == nil || !strings.Contains(err.Error(), "missing database name") {
+		t.Fatalf("expected missing database name error, got %v", err)
+	}
+}
+
+func TestNormalizeDSNAddsDisableSSLForLocalhostOnlyWhenMissing(t *testing.T) {
+	normalized, err := NormalizeDSN("postgres://lore:secret@127.0.0.1:5432/lore")
+	if err != nil {
+		t.Fatalf("NormalizeDSN() error = %v", err)
+	}
+	if !strings.Contains(normalized, "sslmode=disable") {
+		t.Fatalf("expected sslmode=disable for localhost DSN, got %q", normalized)
+	}
+
+	remote, err := NormalizeDSN("postgres://lore:secret@db.internal:5432/lore")
+	if err != nil {
+		t.Fatalf("NormalizeDSN() remote error = %v", err)
+	}
+	if strings.Contains(remote, "sslmode=disable") {
+		t.Fatalf("did not expect sslmode override for remote DSN, got %q", remote)
+	}
+
+	withQuery, err := NormalizeDSN("postgres://lore:secret@localhost:5432/lore?connect_timeout=5")
+	if err != nil {
+		t.Fatalf("NormalizeDSN() localhost query error = %v", err)
+	}
+	if !strings.Contains(withQuery, "connect_timeout=5") || !strings.Contains(withQuery, "sslmode=disable") {
+		t.Fatalf("expected existing query params plus sslmode=disable, got %q", withQuery)
+	}
+
+	withSSLMode, err := NormalizeDSN("postgres://lore:secret@localhost:5432/lore?connect_timeout=5&sslmode=require")
+	if err != nil {
+		t.Fatalf("NormalizeDSN() localhost sslmode error = %v", err)
+	}
+	if !strings.Contains(withSSLMode, "sslmode=require") || strings.Contains(withSSLMode, "sslmode=disable") {
+		t.Fatalf("expected existing sslmode to be preserved, got %q", withSSLMode)
+	}
+}
+
+func TestOpenDatabaseBootstrapsIdempotently(t *testing.T) {
+	name := registerStubDriver(t)
+
+	oldPing := pingDatabase
+	pingDatabase = func(context.Context, *sql.DB) error { return nil }
+	t.Cleanup(func() { pingDatabase = oldPing })
+
+	openFn := func(driverName, dataSourceName string) (*sql.DB, error) {
+		return sql.Open(name, dataSourceName)
+	}
+
+	db, err := OpenDatabase("postgres://lore:secret@127.0.0.1:5432/lore", openFn)
+	if err != nil {
+		t.Fatalf("first OpenDatabase() error = %v", err)
+	}
+	_ = db.Close()
+
+	db, err = OpenDatabase("postgres://lore:secret@127.0.0.1:5432/lore", openFn)
+	if err != nil {
+		t.Fatalf("second OpenDatabase() error = %v", err)
+	}
+	_ = db.Close()
+
+	if execs := stubExecCount(name); execs == 0 {
+		t.Fatalf("expected bootstrap statements to execute")
+	}
+}
+
+func TestOpenDatabaseReturnsPingFailure(t *testing.T) {
+	name := registerStubDriver(t)
+	pingErr := errors.New("dial timeout")
+
+	oldPing := pingDatabase
+	pingDatabase = func(context.Context, *sql.DB) error { return pingErr }
+	t.Cleanup(func() { pingDatabase = oldPing })
+
+	_, err := OpenDatabase("postgres://lore:secret@127.0.0.1:5432/lore", func(driverName, dataSourceName string) (*sql.DB, error) {
+		return sql.Open(name, dataSourceName)
+	})
+	if err == nil || !strings.Contains(err.Error(), "ping postgres database") {
+		t.Fatalf("expected ping failure, got %v", err)
+	}
+}
+
+var (
+	stubMu       sync.Mutex
+	stubCounters = map[string]int{}
+	registerSeq  int
+)
+
+func registerStubDriver(t *testing.T) string {
+	t.Helper()
+	stubMu.Lock()
+	defer stubMu.Unlock()
+	registerSeq++
+	name := fmt.Sprintf("stub-postgres-%d", registerSeq)
+	stubCounters[name] = 0
+	sql.Register(name, stubDriver{name: name})
+	return name
+}
+
+func stubExecCount(name string) int {
+	stubMu.Lock()
+	defer stubMu.Unlock()
+	return stubCounters[name]
+}
+
+type stubDriver struct{ name string }
+
+func (d stubDriver) Open(string) (driver.Conn, error) { return &stubConn{name: d.name}, nil }
+
+type stubConn struct{ name string }
+
+func (c *stubConn) Prepare(string) (driver.Stmt, error) { return nil, errors.New("not implemented") }
+func (c *stubConn) Close() error                        { return nil }
+func (c *stubConn) Begin() (driver.Tx, error)           { return stubTx{}, nil }
+
+func (c *stubConn) ExecContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Result, error) {
+	stubMu.Lock()
+	stubCounters[c.name]++
+	stubMu.Unlock()
+	return driver.RowsAffected(1), nil
+}
+
+func (c *stubConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	if strings.Contains(query, "RETURNING seq") {
+		return &stubRows{columns: []string{"seq"}, values: [][]driver.Value{{int64(1)}}}, nil
+	}
+	return &stubRows{columns: []string{"ignored"}}, nil
+}
+
+type stubTx struct{}
+
+func (stubTx) Commit() error   { return nil }
+func (stubTx) Rollback() error { return nil }
+
+type stubRows struct {
+	columns []string
+	values  [][]driver.Value
+	index   int
+}
+
+func (r *stubRows) Columns() []string { return r.columns }
+func (r *stubRows) Close() error      { return nil }
+
+func (r *stubRows) Next(dest []driver.Value) error {
+	if r.index >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.index])
+	r.index++
+	return nil
+}

--- a/internal/store/contract.go
+++ b/internal/store/contract.go
@@ -1,6 +1,9 @@
 package store
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // Contract is the backend-neutral store boundary consumed by the entrypoints.
 // SQLite remains the only implementation today, but callers should depend on
@@ -60,11 +63,21 @@ type Contract interface {
 func Open(cfg Config) (Contract, error) {
 	switch cfg.SelectedBackend() {
 	case BackendSQLite:
-		return New(cfg)
+		return openSQLiteStore(cfg)
+	case BackendPostgreSQL:
+		pg, err := newPostgresStore(cfg)
+		if err != nil {
+			return nil, err
+		}
+		return pg, nil
 	default:
 		return nil, ErrUnsupportedBackend{Backend: cfg.SelectedBackend()}
 	}
 }
+
+var (
+	openSQLiteStore = func(cfg Config) (Contract, error) { return New(cfg) }
+)
 
 type ErrUnsupportedBackend struct {
 	Backend Backend
@@ -72,4 +85,17 @@ type ErrUnsupportedBackend struct {
 
 func (e ErrUnsupportedBackend) Error() string {
 	return "lore: unsupported store backend " + string(e.Backend)
+}
+
+type ErrUnsupportedBackendFeature struct {
+	Backend Backend
+	Feature string
+}
+
+func (e ErrUnsupportedBackendFeature) Error() string {
+	feature := e.Feature
+	if feature == "" {
+		feature = "requested feature"
+	}
+	return fmt.Sprintf("lore: backend %s does not support %s in this slice", e.Backend, feature)
 }

--- a/internal/store/contract_test.go
+++ b/internal/store/contract_test.go
@@ -44,3 +44,27 @@ func TestOpenRejectsUnsupportedBackend(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestOpenPostgreSQLBackendReturnsOpenError(t *testing.T) {
+	cfg := mustDefaultConfig(t)
+	cfg.Backend = BackendPostgreSQL
+	cfg.DatabaseURL = "postgres://"
+
+	opened, err := Open(cfg)
+	if err == nil {
+		t.Fatalf("expected Open() error for invalid PostgreSQL config")
+	}
+	if opened != nil {
+		t.Fatalf("Open() returned non-nil store on error: %T", opened)
+	}
+	if !strings.Contains(err.Error(), "invalid postgres DATABASE_URL") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUnsupportedBackendFeatureErrorMessage(t *testing.T) {
+	err := ErrUnsupportedBackendFeature{Backend: BackendPostgreSQL, Feature: "search"}
+	if !strings.Contains(err.Error(), "backend postgresql does not support search") {
+		t.Fatalf("unexpected error text: %q", err.Error())
+	}
+}

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -1,0 +1,304 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+)
+
+func newPostgresTestStore(t *testing.T) *PostgresStore {
+	t.Helper()
+
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		t.Skipf("docker unavailable: %v", err)
+	}
+
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: "postgres",
+		Tag:        "16-alpine",
+		Env: []string{
+			"POSTGRES_USER=lore",
+			"POSTGRES_PASSWORD=lore",
+			"POSTGRES_DB=lore",
+		},
+	}, func(config *docker.HostConfig) {
+		config.AutoRemove = true
+		config.RestartPolicy = docker.RestartPolicy{Name: "no"}
+	})
+	if err != nil {
+		t.Skipf("postgres container unavailable: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = pool.Purge(resource)
+	})
+
+	databaseURL := fmt.Sprintf("postgres://lore:lore@127.0.0.1:%s/lore?sslmode=disable", resource.GetPort("5432/tcp"))
+
+	var opened Contract
+	err = pool.Retry(func() error {
+		cfg := Config{
+			Backend:              BackendPostgreSQL,
+			DatabaseURL:          databaseURL,
+			MaxObservationLength: 50000,
+			MaxContextResults:    20,
+			MaxSearchResults:     20,
+			DedupeWindow:         15 * time.Minute,
+		}
+		if opened != nil {
+			_ = opened.Close()
+		}
+		opened, err = Open(cfg)
+		return err
+	})
+	if err != nil {
+		t.Skipf("postgres did not become ready: %v", err)
+	}
+
+	pg, ok := opened.(*PostgresStore)
+	if !ok {
+		_ = opened.Close()
+		t.Fatalf("Open() returned %T, want *PostgresStore", opened)
+	}
+	t.Cleanup(func() { _ = pg.Close() })
+	return pg
+}
+
+func TestPostgresStoreBootstrapAndPingIntegration(t *testing.T) {
+	s := newPostgresTestStore(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.Ping(ctx); err != nil {
+		t.Fatalf("Ping() error = %v", err)
+	}
+
+	for _, table := range []string{"sessions", "observations", "sync_state", "sync_mutations"} {
+		var exists bool
+		if err := s.db.QueryRow(`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = $1)`, table).Scan(&exists); err != nil {
+			t.Fatalf("check table %s: %v", table, err)
+		}
+		if !exists {
+			t.Fatalf("expected table %s to exist", table)
+		}
+	}
+}
+
+func TestPostgresStoreSessionObservationSliceIntegration(t *testing.T) {
+	s := newPostgresTestStore(t)
+
+	if err := s.CreateSession("pg-session", "Lore", "/tmp/lore"); err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+
+	firstID, err := s.AddObservation(AddObservationParams{
+		SessionID: "pg-session",
+		Type:      "architecture",
+		Title:     "Auth boundary",
+		Content:   "Keep postgres additive to sqlite",
+		Project:   "Lore",
+		Scope:     "project",
+		TopicKey:  "architecture/auth-boundary",
+	})
+	if err != nil {
+		t.Fatalf("AddObservation() first error = %v", err)
+	}
+
+	secondID, err := s.AddObservation(AddObservationParams{
+		SessionID: "pg-session",
+		Type:      "architecture",
+		Title:     "Auth boundary",
+		Content:   "Keep postgres additive to sqlite and sync-aware",
+		Project:   "Lore",
+		Scope:     "project",
+		TopicKey:  "architecture/auth-boundary",
+	})
+	if err != nil {
+		t.Fatalf("AddObservation() topic upsert error = %v", err)
+	}
+	if firstID != secondID {
+		t.Fatalf("expected topic upsert to reuse observation id, got %d and %d", firstID, secondID)
+	}
+
+	dupID, err := s.AddObservation(AddObservationParams{
+		SessionID: "pg-session",
+		Type:      "decision",
+		Title:     "Same title",
+		Content:   "Repeated normalized payload for dedupe window",
+		Project:   "Lore",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("AddObservation() dedupe first error = %v", err)
+	}
+	dupID2, err := s.AddObservation(AddObservationParams{
+		SessionID: "pg-session",
+		Type:      "decision",
+		Title:     "Same title",
+		Content:   "Repeated normalized payload for dedupe window",
+		Project:   "Lore",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("AddObservation() dedupe second error = %v", err)
+	}
+	if dupID != dupID2 {
+		t.Fatalf("expected duplicate content to reuse observation id, got %d and %d", dupID, dupID2)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "pg-session",
+		Type:      "discovery",
+		Title:     "Timeline count",
+		Content:   "Postgres timeline total should count the full session",
+		Project:   "Lore",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("AddObservation() timeline count error = %v", err)
+	}
+
+	obs, err := s.GetObservation(firstID)
+	if err != nil {
+		t.Fatalf("GetObservation() error = %v", err)
+	}
+	if obs.RevisionCount != 2 {
+		t.Fatalf("RevisionCount = %d, want 2", obs.RevisionCount)
+	}
+	if !strings.Contains(obs.Content, "sync-aware") {
+		t.Fatalf("expected latest content, got %q", obs.Content)
+	}
+
+	recent, err := s.RecentObservations("lore", "project", 10)
+	if err != nil {
+		t.Fatalf("RecentObservations() error = %v", err)
+	}
+	if len(recent) != 3 {
+		t.Fatalf("expected 3 visible observations, got %d", len(recent))
+	}
+
+	timeline, err := s.Timeline(firstID, 1, 1)
+	if err != nil {
+		t.Fatalf("Timeline() error = %v", err)
+	}
+	if timeline.Focus.ID != firstID {
+		t.Fatalf("timeline focus id = %d, want %d", timeline.Focus.ID, firstID)
+	}
+	if timeline.SessionInfo == nil || timeline.SessionInfo.ID != "pg-session" {
+		t.Fatalf("expected timeline session info for pg-session, got %+v", timeline.SessionInfo)
+	}
+	if timeline.TotalInRange != 3 {
+		t.Fatalf("timeline TotalInRange = %d, want 3", timeline.TotalInRange)
+	}
+
+	updatedTitle := "Auth boundary updated"
+	updatedContent := "Keep postgres additive, sync-aware, and backend-scoped"
+	updated, err := s.UpdateObservation(firstID, UpdateObservationParams{Title: &updatedTitle, Content: &updatedContent})
+	if err != nil {
+		t.Fatalf("UpdateObservation() error = %v", err)
+	}
+	if updated.RevisionCount != 3 {
+		t.Fatalf("updated RevisionCount = %d, want 3", updated.RevisionCount)
+	}
+
+	if err := s.DeleteObservation(firstID, false); err != nil {
+		t.Fatalf("DeleteObservation() error = %v", err)
+	}
+	if _, err := s.GetObservation(firstID); err == nil {
+		t.Fatalf("expected soft-deleted observation to be hidden")
+	}
+
+	recent, err = s.RecentObservations("lore", "project", 10)
+	if err != nil {
+		t.Fatalf("RecentObservations() after delete error = %v", err)
+	}
+	if len(recent) != 2 {
+		t.Fatalf("expected 2 visible observations after soft delete, got %d", len(recent))
+	}
+
+	if err := s.EndSession("pg-session", "done"); err != nil {
+		t.Fatalf("EndSession() error = %v", err)
+	}
+
+	session, err := s.GetSession("pg-session")
+	if err != nil {
+		t.Fatalf("GetSession() error = %v", err)
+	}
+	if session.Summary == nil || *session.Summary != "done" {
+		t.Fatalf("expected session summary to persist, got %+v", session.Summary)
+	}
+
+	rows, err := s.db.Query(`SELECT entity, entity_key, op, payload, project FROM sync_mutations ORDER BY seq ASC`)
+	if err != nil {
+		t.Fatalf("query sync_mutations: %v", err)
+	}
+	defer rows.Close()
+
+	type mutation struct {
+		Entity    string
+		EntityKey string
+		Op        string
+		Payload   string
+		Project   string
+	}
+	mutations := []mutation{}
+	for rows.Next() {
+		var m mutation
+		if err := rows.Scan(&m.Entity, &m.EntityKey, &m.Op, &m.Payload, &m.Project); err != nil {
+			t.Fatalf("scan sync mutation: %v", err)
+		}
+		mutations = append(mutations, m)
+	}
+	if len(mutations) < 6 {
+		t.Fatalf("expected at least 6 sync mutations, got %d", len(mutations))
+	}
+
+	var sawDelete bool
+	for _, m := range mutations {
+		if m.Entity == SyncEntityObservation && m.Op == SyncOpDelete {
+			sawDelete = true
+			var payload map[string]any
+			if err := json.Unmarshal([]byte(m.Payload), &payload); err != nil {
+				t.Fatalf("decode delete payload: %v", err)
+			}
+			if payload["deleted"] != true {
+				t.Fatalf("expected delete payload deleted=true, got %#v", payload["deleted"])
+			}
+		}
+		if m.Project != "lore" {
+			t.Fatalf("expected normalized project lore, got %q", m.Project)
+		}
+	}
+	if !sawDelete {
+		t.Fatalf("expected observation delete mutation to be enqueued")
+	}
+
+	var stateTarget string
+	var lifecycle string
+	var lastEnqueued int64
+	if err := s.db.QueryRow(`SELECT target_key, lifecycle, last_enqueued_seq FROM sync_state WHERE target_key = $1`, DefaultSyncTargetKey).Scan(&stateTarget, &lifecycle, &lastEnqueued); err != nil {
+		t.Fatalf("query sync_state: %v", err)
+	}
+	if stateTarget != DefaultSyncTargetKey || lifecycle != SyncLifecyclePending || lastEnqueued == 0 {
+		t.Fatalf("unexpected sync_state target=%q lifecycle=%q last_enqueued_seq=%d", stateTarget, lifecycle, lastEnqueued)
+	}
+}
+
+func TestPostgresStoreUnsupportedPromptSliceIntegration(t *testing.T) {
+	s := newPostgresTestStore(t)
+	_, err := s.AddPrompt(AddPromptParams{SessionID: "s", Content: "prompt", Project: "lore"})
+	if err == nil {
+		t.Fatalf("expected AddPrompt to be unsupported")
+	}
+	if _, ok := err.(ErrUnsupportedBackendFeature); !ok {
+		t.Fatalf("expected ErrUnsupportedBackendFeature, got %T", err)
+	}
+}
+
+var _ = sql.ErrNoRows

--- a/internal/store/postgres_store.go
+++ b/internal/store/postgres_store.go
@@ -1,0 +1,724 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	postgresbackend "github.com/alferio94/lore/internal/store/backend/postgres"
+)
+
+type PostgresStore struct {
+	db  *sql.DB
+	cfg Config
+}
+
+var _ Contract = (*PostgresStore)(nil)
+
+func newPostgresStore(cfg Config) (*PostgresStore, error) {
+	db, err := postgresbackend.OpenDatabase(cfg.DatabaseURL, sql.Open)
+	if err != nil {
+		return nil, err
+	}
+	return &PostgresStore{db: db, cfg: cfg}, nil
+}
+
+func (s *PostgresStore) Close() error { return s.db.Close() }
+
+func (s *PostgresStore) Ping(ctx context.Context) error {
+	var n int
+	if err := s.db.QueryRowContext(ctx, `SELECT 1`).Scan(&n); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *PostgresStore) MaxObservationLength() int { return s.cfg.MaxObservationLength }
+
+func (s *PostgresStore) CreateSession(id, project, directory string) error {
+	project, _ = NormalizeProject(project)
+	return s.withTx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`
+			INSERT INTO sessions (id, project, directory)
+			VALUES ($1, $2, $3)
+			ON CONFLICT (id) DO UPDATE SET
+				project = CASE WHEN sessions.project = '' THEN EXCLUDED.project ELSE sessions.project END,
+				directory = CASE WHEN sessions.directory = '' THEN EXCLUDED.directory ELSE sessions.directory END
+		`, id, project, directory); err != nil {
+			return err
+		}
+		return s.enqueueSyncMutationTx(tx, SyncEntitySession, id, SyncOpUpsert, syncSessionPayload{ID: id, Project: project, Directory: directory})
+	})
+}
+
+func (s *PostgresStore) EndSession(id, summary string) error {
+	return s.withTx(func(tx *sql.Tx) error {
+		row := tx.QueryRow(`
+			UPDATE sessions
+			SET ended_at = to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'), summary = $1
+			WHERE id = $2
+			RETURNING project, directory, ended_at, summary
+		`, nullableString(summary), id)
+
+		var project, directory, endedAt string
+		var storedSummary *string
+		if err := row.Scan(&project, &directory, &endedAt, &storedSummary); err != nil {
+			if err == sql.ErrNoRows {
+				return nil
+			}
+			return err
+		}
+
+		return s.enqueueSyncMutationTx(tx, SyncEntitySession, id, SyncOpUpsert, syncSessionPayload{
+			ID:        id,
+			Project:   project,
+			Directory: directory,
+			EndedAt:   &endedAt,
+			Summary:   storedSummary,
+		})
+	})
+}
+
+func (s *PostgresStore) GetSession(id string) (*Session, error) {
+	row := s.db.QueryRow(`SELECT id, project, directory, started_at, ended_at, summary FROM sessions WHERE id = $1`, id)
+	var sess Session
+	if err := row.Scan(&sess.ID, &sess.Project, &sess.Directory, &sess.StartedAt, &sess.EndedAt, &sess.Summary); err != nil {
+		return nil, err
+	}
+	return &sess, nil
+}
+
+func (s *PostgresStore) RecentSessions(project string, limit int) ([]SessionSummary, error) {
+	project, _ = NormalizeProject(project)
+	if limit <= 0 {
+		limit = 5
+	}
+	return s.sessionSummaries(project, limit)
+}
+
+func (s *PostgresStore) AllSessions(project string, limit int) ([]SessionSummary, error) {
+	project, _ = NormalizeProject(project)
+	if limit <= 0 {
+		limit = 50
+	}
+	return s.sessionSummaries(project, limit)
+}
+
+func (s *PostgresStore) sessionSummaries(project string, limit int) ([]SessionSummary, error) {
+	query := `
+		SELECT s.id, s.project, s.started_at, s.ended_at, s.summary, COUNT(o.id) AS observation_count
+		FROM sessions s
+		LEFT JOIN observations o ON o.session_id = s.id AND o.deleted_at IS NULL
+		WHERE ($1 = '' OR s.project = $1)
+		GROUP BY s.id, s.project, s.started_at, s.ended_at, s.summary
+		ORDER BY MAX(COALESCE(o.created_at, s.started_at)) DESC
+		LIMIT $2
+	`
+	rows, err := s.db.Query(query, project, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []SessionSummary{}
+	for rows.Next() {
+		var ss SessionSummary
+		if err := rows.Scan(&ss.ID, &ss.Project, &ss.StartedAt, &ss.EndedAt, &ss.Summary, &ss.ObservationCount); err != nil {
+			return nil, err
+		}
+		results = append(results, ss)
+	}
+	return results, rows.Err()
+}
+
+func (s *PostgresStore) AllObservations(project, scope string, limit int) ([]Observation, error) {
+	if limit <= 0 {
+		limit = s.cfg.MaxContextResults
+	}
+	return s.queryObservations(`
+		SELECT id, COALESCE(sync_id, '') AS sync_id, session_id, type, title, content, tool_name, project,
+		       scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		FROM observations
+		WHERE deleted_at IS NULL
+		  AND ($1 = '' OR project = $1)
+		  AND ($2 = '' OR scope = $2)
+		ORDER BY created_at DESC
+		LIMIT $3
+	`, normalizeProjectOnly(project), normalizeScopeMaybe(scope), limit)
+}
+
+func (s *PostgresStore) SessionObservations(sessionID string, limit int) ([]Observation, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	return s.queryObservations(`
+		SELECT id, COALESCE(sync_id, '') AS sync_id, session_id, type, title, content, tool_name, project,
+		       scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		FROM observations
+		WHERE session_id = $1 AND deleted_at IS NULL
+		ORDER BY created_at ASC
+		LIMIT $2
+	`, sessionID, limit)
+}
+
+func (s *PostgresStore) AddObservation(p AddObservationParams) (int64, error) {
+	p.Project, _ = NormalizeProject(p.Project)
+	title := stripPrivateTags(p.Title)
+	content := stripPrivateTags(p.Content)
+	if len(content) > s.cfg.MaxObservationLength {
+		content = content[:s.cfg.MaxObservationLength] + "... [truncated]"
+	}
+	scope := normalizeScope(p.Scope)
+	normHash := hashNormalized(content)
+	topicKey := normalizeTopicKey(p.TopicKey)
+	window := int(s.cfg.DedupeWindow.Seconds())
+	if window <= 0 {
+		window = int((15 * time.Minute).Seconds())
+	}
+
+	var observationID int64
+	err := s.withTx(func(tx *sql.Tx) error {
+		if topicKey != "" {
+			var existingID int64
+			err := tx.QueryRow(`
+				SELECT id
+				FROM observations
+				WHERE topic_key = $1
+				  AND COALESCE(project, '') = COALESCE($2, '')
+				  AND scope = $3
+				  AND deleted_at IS NULL
+				ORDER BY updated_at DESC, created_at DESC
+				LIMIT 1
+			`, topicKey, nullableString(p.Project), scope).Scan(&existingID)
+			if err == nil {
+				if _, err := tx.Exec(`
+					UPDATE observations
+					SET type = $1,
+					    title = $2,
+					    content = $3,
+					    tool_name = $4,
+					    topic_key = $5,
+					    normalized_hash = $6,
+					    revision_count = revision_count + 1,
+					    last_seen_at = to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'),
+					    updated_at = to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS')
+					WHERE id = $7
+				`, p.Type, title, content, nullableString(p.ToolName), nullableString(topicKey), normHash, existingID); err != nil {
+					return err
+				}
+				obs, err := s.getObservationTx(tx, existingID)
+				if err != nil {
+					return err
+				}
+				observationID = existingID
+				return s.enqueueSyncMutationTx(tx, SyncEntityObservation, obs.SyncID, SyncOpUpsert, observationPayloadFromObservation(obs))
+			}
+			if err != sql.ErrNoRows {
+				return err
+			}
+		}
+
+		var existingID int64
+		err := tx.QueryRow(`
+			SELECT id
+			FROM observations
+			WHERE normalized_hash = $1
+			  AND COALESCE(project, '') = COALESCE($2, '')
+			  AND scope = $3
+			  AND type = $4
+			  AND title = $5
+			  AND deleted_at IS NULL
+			  AND created_at >= to_char(timezone('UTC', now()) - ($6 * interval '1 second'), 'YYYY-MM-DD HH24:MI:SS')
+			ORDER BY created_at DESC
+			LIMIT 1
+		`, normHash, nullableString(p.Project), scope, p.Type, title, window).Scan(&existingID)
+		if err == nil {
+			if _, err := tx.Exec(`
+				UPDATE observations
+				SET duplicate_count = duplicate_count + 1,
+				    last_seen_at = to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'),
+				    updated_at = to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS')
+				WHERE id = $1
+			`, existingID); err != nil {
+				return err
+			}
+			obs, err := s.getObservationTx(tx, existingID)
+			if err != nil {
+				return err
+			}
+			observationID = existingID
+			return s.enqueueSyncMutationTx(tx, SyncEntityObservation, obs.SyncID, SyncOpUpsert, observationPayloadFromObservation(obs))
+		}
+		if err != sql.ErrNoRows {
+			return err
+		}
+
+		syncID := newSyncID("obs")
+		if err := tx.QueryRow(`
+			INSERT INTO observations (sync_id, session_id, type, title, content, tool_name, project, scope, topic_key, normalized_hash, revision_count, duplicate_count, last_seen_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 1, 1,
+			        to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'),
+			        to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'))
+			RETURNING id
+		`, syncID, p.SessionID, p.Type, title, content, nullableString(p.ToolName), nullableString(p.Project), scope, nullableString(topicKey), normHash).Scan(&observationID); err != nil {
+			return err
+		}
+		obs, err := s.getObservationTx(tx, observationID)
+		if err != nil {
+			return err
+		}
+		return s.enqueueSyncMutationTx(tx, SyncEntityObservation, obs.SyncID, SyncOpUpsert, observationPayloadFromObservation(obs))
+	})
+	if err != nil {
+		return 0, err
+	}
+	return observationID, nil
+}
+
+func (s *PostgresStore) PassiveCapture(p PassiveCaptureParams) (*PassiveCaptureResult, error) {
+	p.Project, _ = NormalizeProject(p.Project)
+	result := &PassiveCaptureResult{}
+	learnings := ExtractLearnings(p.Content)
+	result.Extracted = len(learnings)
+	if len(learnings) == 0 {
+		return result, nil
+	}
+
+	for _, learning := range learnings {
+		var existingID int64
+		err := s.db.QueryRow(`
+			SELECT id FROM observations
+			WHERE normalized_hash = $1
+			  AND COALESCE(project, '') = COALESCE($2, '')
+			  AND deleted_at IS NULL
+			LIMIT 1
+		`, hashNormalized(learning), nullableString(p.Project)).Scan(&existingID)
+		if err == nil {
+			result.Duplicates++
+			continue
+		}
+		if err != nil && err != sql.ErrNoRows {
+			return result, err
+		}
+
+		title := learning
+		if len(title) > 60 {
+			title = title[:60] + "..."
+		}
+		if _, err := s.AddObservation(AddObservationParams{
+			SessionID: p.SessionID,
+			Type:      "passive",
+			Title:     title,
+			Content:   learning,
+			Project:   p.Project,
+			Scope:     "project",
+			ToolName:  p.Source,
+		}); err != nil {
+			return result, fmt.Errorf("passive capture save: %w", err)
+		}
+		result.Saved++
+	}
+
+	return result, nil
+}
+
+func (s *PostgresStore) RecentObservations(project, scope string, limit int) ([]Observation, error) {
+	if limit <= 0 {
+		limit = s.cfg.MaxContextResults
+	}
+	return s.queryObservations(`
+		SELECT id, COALESCE(sync_id, '') AS sync_id, session_id, type, title, content, tool_name, project,
+		       scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		FROM observations
+		WHERE deleted_at IS NULL
+		  AND ($1 = '' OR project = $1)
+		  AND ($2 = '' OR scope = $2)
+		ORDER BY created_at DESC
+		LIMIT $3
+	`, normalizeProjectOnly(project), normalizeScopeMaybe(scope), limit)
+}
+
+func (s *PostgresStore) Search(query string, opts SearchOptions) ([]SearchResult, error) {
+	return nil, s.unsupported("search")
+}
+
+func (s *PostgresStore) SearchWithMetadata(query string, opts SearchOptions) (*SearchWithMetadataResult, error) {
+	return nil, s.unsupported("search with metadata")
+}
+
+func (s *PostgresStore) GetObservation(id int64) (*Observation, error) {
+	row := s.db.QueryRow(`
+		SELECT id, COALESCE(sync_id, '') AS sync_id, session_id, type, title, content, tool_name, project,
+		       scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		FROM observations
+		WHERE id = $1 AND deleted_at IS NULL
+	`, id)
+	var o Observation
+	if err := scanObservation(row, &o); err != nil {
+		return nil, err
+	}
+	return &o, nil
+}
+
+func (s *PostgresStore) UpdateObservation(id int64, p UpdateObservationParams) (*Observation, error) {
+	var updated *Observation
+	err := s.withTx(func(tx *sql.Tx) error {
+		obs, err := s.getObservationTx(tx, id)
+		if err != nil {
+			return err
+		}
+
+		typ := obs.Type
+		title := obs.Title
+		content := obs.Content
+		project := derefString(obs.Project)
+		scope := obs.Scope
+		topicKey := derefString(obs.TopicKey)
+
+		if p.Type != nil {
+			typ = *p.Type
+		}
+		if p.Title != nil {
+			title = stripPrivateTags(*p.Title)
+		}
+		if p.Content != nil {
+			content = stripPrivateTags(*p.Content)
+			if len(content) > s.cfg.MaxObservationLength {
+				content = content[:s.cfg.MaxObservationLength] + "... [truncated]"
+			}
+		}
+		if p.Project != nil {
+			project, _ = NormalizeProject(*p.Project)
+		}
+		if p.Scope != nil {
+			scope = normalizeScope(*p.Scope)
+		}
+		if p.TopicKey != nil {
+			topicKey = normalizeTopicKey(*p.TopicKey)
+		}
+
+		if _, err := tx.Exec(`
+			UPDATE observations
+			SET type = $1,
+			    title = $2,
+			    content = $3,
+			    project = $4,
+			    scope = $5,
+			    topic_key = $6,
+			    normalized_hash = $7,
+			    revision_count = revision_count + 1,
+			    updated_at = to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS')
+			WHERE id = $8 AND deleted_at IS NULL
+		`, typ, title, content, nullableString(project), scope, nullableString(topicKey), hashNormalized(content), id); err != nil {
+			return err
+		}
+
+		updated, err = s.getObservationTx(tx, id)
+		if err != nil {
+			return err
+		}
+		return s.enqueueSyncMutationTx(tx, SyncEntityObservation, updated.SyncID, SyncOpUpsert, observationPayloadFromObservation(updated))
+	})
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func (s *PostgresStore) DeleteObservation(id int64, hardDelete bool) error {
+	return s.withTx(func(tx *sql.Tx) error {
+		obs, err := s.getObservationTx(tx, id)
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		deletedAt := Now()
+		if hardDelete {
+			if _, err := tx.Exec(`DELETE FROM observations WHERE id = $1`, id); err != nil {
+				return err
+			}
+		} else {
+			if err := tx.QueryRow(`
+				UPDATE observations
+				SET deleted_at = to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'),
+				    updated_at = to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS')
+				WHERE id = $1 AND deleted_at IS NULL
+				RETURNING deleted_at
+			`, id).Scan(&deletedAt); err != nil {
+				return err
+			}
+		}
+
+		return s.enqueueSyncMutationTx(tx, SyncEntityObservation, obs.SyncID, SyncOpDelete, syncObservationPayload{
+			SyncID:     obs.SyncID,
+			Project:    obs.Project,
+			Deleted:    true,
+			DeletedAt:  &deletedAt,
+			HardDelete: hardDelete,
+		})
+	})
+}
+
+func (s *PostgresStore) Timeline(observationID int64, before, after int) (*TimelineResult, error) {
+	if before <= 0 {
+		before = 5
+	}
+	if after <= 0 {
+		after = 5
+	}
+
+	focus, err := s.GetObservation(observationID)
+	if err != nil {
+		return nil, fmt.Errorf("timeline: observation #%d not found: %w", observationID, err)
+	}
+
+	session, err := s.GetSession(focus.SessionID)
+	if err != nil {
+		session = nil
+	}
+
+	beforeEntries, err := s.queryTimelineEntries(`
+		SELECT id, session_id, type, title, content, tool_name, project,
+		       scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		FROM observations
+		WHERE session_id = $1 AND id < $2 AND deleted_at IS NULL
+		ORDER BY id DESC
+		LIMIT $3
+	`, focus.SessionID, observationID, before)
+	if err != nil {
+		return nil, fmt.Errorf("timeline: before query: %w", err)
+	}
+	for i, j := 0, len(beforeEntries)-1; i < j; i, j = i+1, j-1 {
+		beforeEntries[i], beforeEntries[j] = beforeEntries[j], beforeEntries[i]
+	}
+
+	afterEntries, err := s.queryTimelineEntries(`
+		SELECT id, session_id, type, title, content, tool_name, project,
+		       scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		FROM observations
+		WHERE session_id = $1 AND id > $2 AND deleted_at IS NULL
+		ORDER BY id ASC
+		LIMIT $3
+	`, focus.SessionID, observationID, after)
+	if err != nil {
+		return nil, fmt.Errorf("timeline: after query: %w", err)
+	}
+
+	var totalInRange int
+	if err := s.db.QueryRow(`
+		SELECT COUNT(*)
+		FROM observations
+		WHERE session_id = $1 AND deleted_at IS NULL
+	`, focus.SessionID).Scan(&totalInRange); err != nil {
+		return nil, fmt.Errorf("timeline: count query: %w", err)
+	}
+
+	return &TimelineResult{
+		Focus:        *focus,
+		Before:       beforeEntries,
+		After:        afterEntries,
+		SessionInfo:  session,
+		TotalInRange: totalInRange,
+	}, nil
+}
+
+func (s *PostgresStore) AddPrompt(AddPromptParams) (int64, error) { return 0, s.unsupported("prompts") }
+func (s *PostgresStore) RecentPrompts(string, int) ([]Prompt, error) {
+	return nil, s.unsupported("prompts")
+}
+func (s *PostgresStore) SearchPrompts(string, string, int) ([]Prompt, error) {
+	return nil, s.unsupported("prompt search")
+}
+func (s *PostgresStore) FormatContext(string, string) (string, error) {
+	return "", s.unsupported("formatted context")
+}
+func (s *PostgresStore) Stats() (*Stats, error)       { return nil, s.unsupported("stats") }
+func (s *PostgresStore) Export() (*ExportData, error) { return nil, s.unsupported("export") }
+func (s *PostgresStore) Import(*ExportData) (*ImportResult, error) {
+	return nil, s.unsupported("import")
+}
+func (s *PostgresStore) GetSyncedChunks() (map[string]bool, error) {
+	return nil, s.unsupported("synced chunks")
+}
+func (s *PostgresStore) RecordSyncedChunk(string) error { return s.unsupported("synced chunks") }
+func (s *PostgresStore) MigrateProject(string, string) (*MigrateResult, error) {
+	return nil, s.unsupported("project migration")
+}
+func (s *PostgresStore) ListProjectNames() ([]string, error) {
+	return nil, s.unsupported("project listing")
+}
+func (s *PostgresStore) ListProjectsWithStats() ([]ProjectStats, error) {
+	return nil, s.unsupported("project stats")
+}
+func (s *PostgresStore) CountObservationsForProject(string) (int, error) {
+	return 0, s.unsupported("project counts")
+}
+func (s *PostgresStore) PruneProject(string) (*PruneResult, error) {
+	return nil, s.unsupported("project pruning")
+}
+func (s *PostgresStore) MergeProjects([]string, string) (*MergeResult, error) {
+	return nil, s.unsupported("project merge")
+}
+func (s *PostgresStore) ListSkills(ListSkillsParams) ([]Skill, error) {
+	return nil, s.unsupported("skills catalog")
+}
+func (s *PostgresStore) GetSkill(string) (*Skill, error) { return nil, s.unsupported("skills catalog") }
+func (s *PostgresStore) CreateSkill(CreateSkillParams) (*Skill, error) {
+	return nil, s.unsupported("skills catalog")
+}
+func (s *PostgresStore) UpdateSkill(string, UpdateSkillParams) (*Skill, error) {
+	return nil, s.unsupported("skills catalog")
+}
+func (s *PostgresStore) DeleteSkill(string, string) error { return s.unsupported("skills catalog") }
+func (s *PostgresStore) ListStacks() ([]Stack, error)     { return nil, s.unsupported("stack catalog") }
+func (s *PostgresStore) CreateStack(string, string) (*Stack, error) {
+	return nil, s.unsupported("stack catalog")
+}
+func (s *PostgresStore) DeleteStack(int64) error { return s.unsupported("stack catalog") }
+func (s *PostgresStore) ListCategories() ([]Category, error) {
+	return nil, s.unsupported("category catalog")
+}
+func (s *PostgresStore) CreateCategory(string, string) (*Category, error) {
+	return nil, s.unsupported("category catalog")
+}
+func (s *PostgresStore) DeleteCategory(int64) error { return s.unsupported("category catalog") }
+func (s *PostgresStore) AdminStats() (AdminStats, error) {
+	return AdminStats{}, s.unsupported("admin stats")
+}
+func (s *PostgresStore) UpsertUser(string, string, string, string) (*User, error) {
+	return nil, s.unsupported("users")
+}
+func (s *PostgresStore) ListUsers() ([]User, error) { return nil, s.unsupported("users") }
+func (s *PostgresStore) UpdateUserRole(int64, string) (*User, error) {
+	return nil, s.unsupported("users")
+}
+
+func (s *PostgresStore) unsupported(feature string) error {
+	return ErrUnsupportedBackendFeature{Backend: BackendPostgreSQL, Feature: feature}
+}
+
+func (s *PostgresStore) withTx(fn func(tx *sql.Tx) error) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *PostgresStore) ensureSyncStateTx(tx *sql.Tx, targetKey string) error {
+	_, err := tx.Exec(`
+		INSERT INTO sync_state (target_key, lifecycle, updated_at)
+		VALUES ($1, $2, to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'))
+		ON CONFLICT (target_key) DO NOTHING
+	`, targetKey, SyncLifecycleIdle)
+	return err
+}
+
+func (s *PostgresStore) enqueueSyncMutationTx(tx *sql.Tx, entity, entityKey, op string, payload any) error {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	project := extractProjectFromPayload(payload)
+	if err := s.ensureSyncStateTx(tx, DefaultSyncTargetKey); err != nil {
+		return err
+	}
+	var seq int64
+	if err := tx.QueryRow(`
+		INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING seq
+	`, DefaultSyncTargetKey, entity, entityKey, op, string(encoded), SyncSourceLocal, project).Scan(&seq); err != nil {
+		return err
+	}
+	_, err = tx.Exec(`
+		UPDATE sync_state
+		SET lifecycle = $1, last_enqueued_seq = $2, updated_at = to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS')
+		WHERE target_key = $3
+	`, SyncLifecyclePending, seq, DefaultSyncTargetKey)
+	return err
+}
+
+func (s *PostgresStore) getObservationTx(tx *sql.Tx, id int64) (*Observation, error) {
+	row := tx.QueryRow(`
+		SELECT id, COALESCE(sync_id, '') AS sync_id, session_id, type, title, content, tool_name, project,
+		       scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		FROM observations
+		WHERE id = $1 AND deleted_at IS NULL
+	`, id)
+	var o Observation
+	if err := scanObservation(row, &o); err != nil {
+		return nil, err
+	}
+	return &o, nil
+}
+
+func (s *PostgresStore) queryObservations(query string, args ...any) ([]Observation, error) {
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []Observation{}
+	for rows.Next() {
+		var o Observation
+		if err := scanObservation(rows, &o); err != nil {
+			return nil, err
+		}
+		results = append(results, o)
+	}
+	return results, rows.Err()
+}
+
+func (s *PostgresStore) queryTimelineEntries(query string, args ...any) ([]TimelineEntry, error) {
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []TimelineEntry{}
+	for rows.Next() {
+		var e TimelineEntry
+		if err := rows.Scan(
+			&e.ID, &e.SessionID, &e.Type, &e.Title, &e.Content,
+			&e.ToolName, &e.Project, &e.Scope, &e.TopicKey, &e.RevisionCount, &e.DuplicateCount, &e.LastSeenAt,
+			&e.CreatedAt, &e.UpdatedAt, &e.DeletedAt,
+		); err != nil {
+			return nil, err
+		}
+		results = append(results, e)
+	}
+	return results, rows.Err()
+}
+
+func scanObservation(scanner interface{ Scan(dest ...any) error }, o *Observation) error {
+	return scanner.Scan(
+		&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content,
+		&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt,
+		&o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
+	)
+}
+
+func normalizeProjectOnly(project string) string {
+	project, _ = NormalizeProject(project)
+	return project
+}
+
+func normalizeScopeMaybe(scope string) string {
+	if strings.TrimSpace(scope) == "" {
+		return ""
+	}
+	return normalizeScope(scope)
+}

--- a/internal/store/postgres_store_test.go
+++ b/internal/store/postgres_store_test.go
@@ -1,0 +1,35 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPostgresStoreUnsupportedMethodsReturnExplicitError(t *testing.T) {
+	s := &PostgresStore{cfg: Config{Backend: BackendPostgreSQL}}
+
+	checks := []struct {
+		name string
+		err  error
+	}{
+		{name: "search", err: func() error { _, err := s.Search("auth", SearchOptions{}); return err }()},
+		{name: "prompts", err: func() error { _, err := s.AddPrompt(AddPromptParams{}); return err }()},
+		{name: "skills catalog", err: func() error { _, err := s.ListSkills(ListSkillsParams{}); return err }()},
+	}
+
+	for _, tc := range checks {
+		if tc.err == nil {
+			t.Fatalf("%s: expected unsupported error", tc.name)
+		}
+		unsupported, ok := tc.err.(ErrUnsupportedBackendFeature)
+		if !ok {
+			t.Fatalf("%s: error type = %T, want ErrUnsupportedBackendFeature", tc.name, tc.err)
+		}
+		if unsupported.Backend != BackendPostgreSQL {
+			t.Fatalf("%s: backend = %q, want %q", tc.name, unsupported.Backend, BackendPostgreSQL)
+		}
+		if !strings.Contains(tc.err.Error(), tc.name) {
+			t.Fatalf("%s: error text %q missing feature name", tc.name, tc.err.Error())
+		}
+	}
+}

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -317,14 +317,16 @@ type Backend string
 
 const BackendSQLite Backend = "sqlite"
 
+const BackendPostgreSQL Backend = "postgresql"
+
 type Config struct {
-	Backend             Backend
-	DataDir             string
-	DatabaseURL         string
+	Backend              Backend
+	DataDir              string
+	DatabaseURL          string
 	MaxObservationLength int
-	MaxContextResults   int
-	MaxSearchResults    int
-	DedupeWindow        time.Duration
+	MaxContextResults    int
+	MaxSearchResults     int
+	DedupeWindow         time.Duration
 }
 
 func (cfg Config) SelectedBackend() Backend {

--- a/scripts/validate-postgres-local.sh
+++ b/scripts/validate-postgres-local.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.postgres.yml"
+TMP_DIR="$ROOT_DIR/.tmp/postgres-validate"
+DATA_DIR="$TMP_DIR/data"
+LOG_FILE="$TMP_DIR/lore.log"
+PORT="17437"
+BASE_URL="http://127.0.0.1:$PORT"
+DATABASE_URL_DEFAULT="postgres://lore:lore@127.0.0.1:5432/lore?sslmode=disable"
+DATABASE_URL_VALUE="${DATABASE_URL:-$DATABASE_URL_DEFAULT}"
+
+fail() {
+  printf '%s\n' "ERROR: $1" >&2
+  exit 1
+}
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+  fail "Missing required file: docker-compose.postgres.yml"
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  fail "docker binary not found"
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  fail "'docker compose' is not available (Docker Compose plugin missing)"
+fi
+
+if ! command -v go >/dev/null 2>&1; then
+  fail "go binary not found"
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  fail "curl binary not found"
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  fail "python3 binary not found"
+fi
+
+mkdir -p "$DATA_DIR"
+rm -f "$LOG_FILE"
+
+cleanup() {
+  if [ -n "${APP_PID:-}" ] && kill -0 "$APP_PID" >/dev/null 2>&1; then
+    kill "$APP_PID" >/dev/null 2>&1 || true
+    wait "$APP_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+docker compose -f "$COMPOSE_FILE" up -d postgres
+
+attempt=0
+while [ "$attempt" -lt 30 ]; do
+  attempt=$((attempt + 1))
+  if docker compose -f "$COMPOSE_FILE" exec -T postgres pg_isready -U lore -d lore >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! docker compose -f "$COMPOSE_FILE" exec -T postgres pg_isready -U lore -d lore >/dev/null 2>&1; then
+  fail "postgres did not become ready"
+fi
+
+LORE_DATA_DIR="$DATA_DIR" \
+LORE_PORT="$PORT" \
+DATABASE_URL="$DATABASE_URL_VALUE" \
+go run ./cmd/lore serve >"$LOG_FILE" 2>&1 &
+APP_PID=$!
+
+attempt=0
+while [ "$attempt" -lt 30 ]; do
+  attempt=$((attempt + 1))
+  if curl -fsS "$BASE_URL/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -fsS "$BASE_URL/health" >/dev/null 2>&1; then
+  if [ -f "$LOG_FILE" ]; then
+    printf '%s\n' "Lore server logs:" >&2
+    cat "$LOG_FILE" >&2
+  fi
+  fail "lore serve did not become healthy"
+fi
+
+curl -fsS -X POST "$BASE_URL/sessions" \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"pg-local-session","project":"lore","directory":"/tmp/lore"}' >/dev/null
+
+CREATE_RESPONSE="$(curl -fsS -X POST "$BASE_URL/observations" \
+  -H 'Content-Type: application/json' \
+  -d '{"session_id":"pg-local-session","type":"architecture","title":"Postgres local validation","content":"Validate postgres-backed health and observation flow locally","project":"lore","scope":"project","topic_key":"architecture/postgres-local-validation"}')"
+
+OBS_ID="$(printf '%s' "$CREATE_RESPONSE" | python3 -c 'import json,sys; print(int(json.load(sys.stdin)["id"]))')"
+
+curl -fsS "$BASE_URL/observations/$OBS_ID" >/dev/null
+
+curl -fsS -X PATCH "$BASE_URL/observations/$OBS_ID" \
+  -H 'Content-Type: application/json' \
+  -d '{"content":"Validate postgres-backed health, update, and delete flow locally"}' >/dev/null
+
+curl -fsS "$BASE_URL/timeline?observation_id=$OBS_ID&before=1&after=1" >/dev/null
+
+curl -fsS -X DELETE "$BASE_URL/observations/$OBS_ID" >/dev/null
+
+curl -fsS -X POST "$BASE_URL/sessions/pg-local-session/end" \
+  -H 'Content-Type: application/json' \
+  -d '{"summary":"local postgres validation complete"}' >/dev/null
+
+SEARCH_STATUS="$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/search?q=postgres&project=lore&scope=project&limit=10")"
+if [ "$SEARCH_STATUS" != "500" ]; then
+  fail "expected unsupported PostgreSQL search slice to return HTTP 500, got $SEARCH_STATUS"
+fi
+
+printf '%s\n' "Local PostgreSQL validation passed."


### PR DESCRIPTION
Closes #9

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds a PostgreSQL backend bootstrap behind the existing store contract while preserving SQLite as the default local backend.
- Wires `DATABASE_URL` selection across storage-opening commands and keeps non-PostgreSQL URLs on SQLite.
- Adds PostgreSQL schema/bootstrap tests, server E2E coverage, Docker Compose, and local validation script.

## Changes
| File | Change |
|------|--------|
| `internal/store/backend/postgres/postgres.go` | Adds PostgreSQL DSN normalization, connection ping, and idempotent bootstrap DDL. |
| `internal/store/postgres_store.go` | Implements the approved session, observation, timeline, and sync journal slice. |
| `cmd/lore/*` | Applies backend selection consistently and adds runtime wiring tests. |
| `internal/server/*_test.go` | Adds backend-neutral health and PostgreSQL slice E2E coverage. |
| `docker-compose.postgres.yml`, `scripts/validate-postgres-local.sh` | Adds local PostgreSQL validation path. |
| `.env.example`, `DOCS.md`, `docs/INSTALLATION.md` | Documents PostgreSQL selection rules and validation steps. |

## Test Plan
- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server -run TestPostgresApprovedSliceE2E`
- [x] Manually tested the affected functionality: `./scripts/validate-postgres-local.sh`
- [x] Additional validation: `go vet ./...`
- [x] Judgment Day adversarial review approved after fixes

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran unit tests locally
- [x] Ran e2e tests locally
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers