### PR TITLE
feat(store): add PostgreSQL skill catalog parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The first Railway preview keeps Lore on the existing hosted contract: deploy `lo
 
 Use `LORE_ENV=staging` for Railway. Railway injects `PORT`; leave `LORE_PORT` unset unless you intentionally need to override the platform port. `DATABASE_URL` must be PostgreSQL, and `LORE_JWT_SECRET` must be persistent and at least 32 bytes. `LORE_BASE_URL` must be the public Railway URL so admin links and callbacks resolve correctly.
 
-After deploy, run a `/health` and `/mcp` smoke check: `curl "$LORE_BASE_URL/health"` should return `200` only when the PostgreSQL-backed store is reachable, and an MCP client should initialize successfully against `"$LORE_BASE_URL/mcp"`.
+After deploy, run a `/health` and `/mcp` smoke check: `curl "$LORE_BASE_URL/health"` should return `200` only when the PostgreSQL-backed store is reachable, and an MCP client should initialize successfully against `"$LORE_BASE_URL/mcp"`. For PostgreSQL-backed hosted/runtime validation, the minimum MCP smoke now includes `lore_list_skills`, `lore_get_skill`, or `skills://{name}` against seeded skill data rather than expecting the skill catalog to be unsupported.
 
 No web view/dashboard/browser UI expansion, TUI changes, agent configurators/plugins, or production auth/multi-user hardening are included in this preview.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -146,7 +146,7 @@ The response should be `200 OK` only when the PostgreSQL-backed store is reachab
 ${LORE_BASE_URL}/mcp
 ```
 
-The smoke is complete when the MCP client initializes successfully and can perform a minimal memory write/read flow (for example `lore_save` followed by `lore_search` or `lore_get_observation`).
+The smoke is complete when the MCP client initializes successfully and can perform a minimal runtime flow. For PostgreSQL-backed hosted validation, include skill-catalog reads such as `lore_list_skills`, `lore_get_skill`, or `skills://{name}` after seeding a test skill.
 
 Excluded scope: no web view/dashboard/browser UI work, no TUI work, no agent configurators/plugins, and no production auth or multi-user hardening.
 
@@ -180,11 +180,11 @@ Backend selection:
 
 ## Local PostgreSQL validation
 
-This repo includes a host-app validation path for the first PostgreSQL slice:
+This repo includes a host-app validation path for the PostgreSQL shared-runtime surface:
 
 ```bash
 docker compose -f docker-compose.postgres.yml up -d postgres
 scripts/validate-postgres-local.sh
 ```
 
-That path validates Lore's shared-runtime backend behavior while still running the Go app locally.
+That path validates Lore's shared-runtime backend behavior while still running the Go app locally. The script seeds a skill directly into the PostgreSQL-backed store, then smokes `lore_list_skills`, `lore_get_skill`, and `skills://{name}` through `/mcp` so the hosted/runtime support boundary matches current PostgreSQL behavior.

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	serverpkg "github.com/alferio94/lore/internal/server"
 	"github.com/alferio94/lore/internal/store"
 	mcppkg "github.com/mark3labs/mcp-go/mcp"
 	"github.com/ory/dockertest/v3"
@@ -2122,7 +2124,7 @@ func TestHandleSaveDefaultProjectDoesNotOverrideExplicit(t *testing.T) {
 // seedSkill is a test helper that creates a skill in the store.
 // stack and category parameters are retained for signature compatibility with
 // existing call sites but are not yet used — catalog IDs are set in Phase 3/4.
-func seedSkill(t *testing.T, s *store.Store, name, displayName, stack, category, triggers, content string) {
+func seedSkill(t *testing.T, s store.Contract, name, displayName, stack, category, triggers, content string) {
 	t.Helper()
 	_, err := s.CreateSkill(store.CreateSkillParams{
 		Name:        name,
@@ -2140,7 +2142,7 @@ func seedSkill(t *testing.T, s *store.Store, name, displayName, stack, category,
 }
 
 // seedSkillWithCatalog creates a skill with actual stack/category catalog relationships.
-func seedSkillWithCatalog(t *testing.T, s *store.Store, name, displayName string, stackIDs, categoryIDs []int64, triggers, content string) {
+func seedSkillWithCatalog(t *testing.T, s store.Contract, name, displayName string, stackIDs, categoryIDs []int64, triggers, content string) {
 	t.Helper()
 	_, err := s.CreateSkill(store.CreateSkillParams{
 		Name:        name,
@@ -2375,6 +2377,61 @@ func TestHandleListSkillsResponseHasStacksArray(t *testing.T) {
 	}
 }
 
+func TestHandleListSkillsPostgresHostedPath(t *testing.T) {
+	pg := newPostgresMCPTestStore(t)
+
+	goStack, err := pg.CreateStack("go", "Go")
+	if err != nil {
+		t.Fatalf("CreateStack: %v", err)
+	}
+	patterns, err := pg.CreateCategory("patterns", "Patterns")
+	if err != nil {
+		t.Fatalf("CreateCategory: %v", err)
+	}
+
+	seedSkillWithCatalog(t, pg, "pg-hosted-list", "Hosted Postgres List", []int64{goStack.ID}, []int64{patterns.ID}, "When validating hosted postgres MCP", "# hidden list content")
+
+	srv := serverpkg.NewWithConfig(pg, serverpkg.Config{Host: "127.0.0.1", Port: 0, Version: "pg-smoke"})
+	srv.SetMCPHandler(NewHTTPHandler(pg, "postgres-runtime"))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	_ = decodeMCPBody(t, postMCPJSON(t, ts.URL+"/mcp", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2024-11-05",
+			"capabilities":    map[string]any{},
+			"clientInfo": map[string]any{
+				"name":    "postgres-hosted-list",
+				"version": "1.0",
+			},
+		},
+	}))
+
+	text := firstMCPText(t, decodeMCPBody(t, postMCPJSON(t, ts.URL+"/mcp", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "lore_list_skills",
+			"arguments": map[string]any{
+				"query": "hosted postgres MCP",
+			},
+		},
+	})))
+	if !strings.Contains(text, "pg-hosted-list") {
+		t.Fatalf("expected Postgres-backed skill in output, got %q", text)
+	}
+	if !strings.Contains(text, `"stacks"`) || !strings.Contains(text, `"categories"`) {
+		t.Fatalf("expected catalog arrays in list output, got %q", text)
+	}
+	if strings.Contains(text, "hidden list content") || strings.Contains(text, `"compact_rules"`) {
+		t.Fatalf("list output should stay metadata-only, got %q", text)
+	}
+}
+
 // ─── 4.3: lore_get_skill handler tests ───────────────────────────────────────
 
 func TestHandleGetSkillFound(t *testing.T) {
@@ -2511,6 +2568,70 @@ func TestHandleGetSkillEmptyArraysWhenNoRelationships(t *testing.T) {
 	}
 }
 
+func TestHandleGetSkillPostgresHostedPath(t *testing.T) {
+	pg := newPostgresMCPTestStore(t)
+
+	goStack, err := pg.CreateStack("go", "Go")
+	if err != nil {
+		t.Fatalf("CreateStack: %v", err)
+	}
+	patterns, err := pg.CreateCategory("patterns", "Patterns")
+	if err != nil {
+		t.Fatalf("CreateCategory: %v", err)
+	}
+
+	_, err = pg.CreateSkill(store.CreateSkillParams{
+		Name:         "pg-hosted-get",
+		DisplayName:  "Hosted Postgres Get",
+		StackIDs:     []int64{goStack.ID},
+		CategoryIDs:  []int64{patterns.ID},
+		Triggers:     "When validating hosted postgres skill reads",
+		Content:      "# postgres skill body",
+		CompactRules: "Return terse bullets.",
+		ChangedBy:    "test",
+	})
+	if err != nil {
+		t.Fatalf("CreateSkill: %v", err)
+	}
+
+	srv := serverpkg.NewWithConfig(pg, serverpkg.Config{Host: "127.0.0.1", Port: 0, Version: "pg-smoke"})
+	srv.SetMCPHandler(NewHTTPHandler(pg, "postgres-runtime"))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	_ = decodeMCPBody(t, postMCPJSON(t, ts.URL+"/mcp", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      3,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2024-11-05",
+			"capabilities":    map[string]any{},
+			"clientInfo": map[string]any{
+				"name":    "postgres-hosted-get",
+				"version": "1.0",
+			},
+		},
+	}))
+
+	text := firstMCPText(t, decodeMCPBody(t, postMCPJSON(t, ts.URL+"/mcp", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      4,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "lore_get_skill",
+			"arguments": map[string]any{
+				"name": "pg-hosted-get",
+			},
+		},
+	})))
+	if !strings.Contains(text, "# postgres skill body") || !strings.Contains(text, `"compact_rules":"Return terse bullets."`) {
+		t.Fatalf("expected full skill payload from Postgres-backed get, got %q", text)
+	}
+	if !strings.Contains(text, `"stacks"`) || !strings.Contains(text, `"categories"`) {
+		t.Fatalf("expected catalog arrays in get output, got %q", text)
+	}
+}
+
 // ─── 4.6: skills:// resource handler tests ───────────────────────────────────
 
 func TestHandleSkillResourceFound(t *testing.T) {
@@ -2551,6 +2672,54 @@ func TestHandleSkillResourceNotFound(t *testing.T) {
 	_, err := h(context.Background(), req)
 	if err == nil {
 		t.Fatal("expected error for non-existent resource, got nil")
+	}
+}
+
+func TestHandleSkillResourcePostgresHostedPath(t *testing.T) {
+	pg := newPostgresMCPTestStore(t)
+	seedSkill(t, pg, "pg-hosted-resource", "Hosted Postgres Resource", "", "", "When reading a Postgres-hosted MCP resource", "# postgres hosted resource")
+
+	srv := serverpkg.NewWithConfig(pg, serverpkg.Config{Host: "127.0.0.1", Port: 0, Version: "pg-smoke"})
+	srv.SetMCPHandler(NewHTTPHandler(pg, "postgres-runtime"))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	_ = decodeMCPBody(t, postMCPJSON(t, ts.URL+"/mcp", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      5,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2024-11-05",
+			"capabilities":    map[string]any{},
+			"clientInfo": map[string]any{
+				"name":    "postgres-hosted-resource",
+				"version": "1.0",
+			},
+		},
+	}))
+
+	body := decodeMCPBody(t, postMCPJSON(t, ts.URL+"/mcp", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      6,
+		"method":  "resources/read",
+		"params": map[string]any{
+			"uri": "skills://pg-hosted-resource",
+		},
+	}))
+	result, ok := body["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("resource result missing: %v", body)
+	}
+	contents, ok := result["contents"].([]any)
+	if !ok || len(contents) != 1 {
+		t.Fatalf("unexpected resource contents payload: %v", result["contents"])
+	}
+	text, ok := contents[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected object content, got %T", contents[0])
+	}
+	if text["uri"] != "skills://pg-hosted-resource" || text["mimeType"] != "text/markdown" || !strings.Contains(text["text"].(string), "postgres hosted resource") {
+		t.Fatalf("unexpected resource contents: %+v", text)
 	}
 }
 

--- a/internal/store/backend/postgres/postgres.go
+++ b/internal/store/backend/postgres/postgres.go
@@ -133,6 +133,69 @@ func Bootstrap(db *sql.DB) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_pg_sync_mutations_target_seq ON sync_mutations(target_key, seq)`,
 		`CREATE INDEX IF NOT EXISTS idx_pg_sync_mutations_project ON sync_mutations(project)`,
+		`CREATE TABLE IF NOT EXISTS skills (
+			id BIGSERIAL PRIMARY KEY,
+			name TEXT NOT NULL UNIQUE,
+			display_name TEXT NOT NULL,
+			triggers TEXT NOT NULL DEFAULT '',
+			content TEXT NOT NULL,
+			compact_rules TEXT NOT NULL DEFAULT '',
+			version INTEGER NOT NULL DEFAULT 1,
+			is_active BOOLEAN NOT NULL DEFAULT TRUE,
+			changed_by TEXT NOT NULL DEFAULT 'system',
+			created_at TEXT NOT NULL DEFAULT to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'),
+			updated_at TEXT NOT NULL DEFAULT to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS')
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_skills_name ON skills(name)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_skills_active ON skills(is_active)`,
+		fmt.Sprintf(`CREATE INDEX IF NOT EXISTS idx_pg_skills_search_vector ON skills USING GIN ((%s))`, skillSearchVectorExpression()),
+		`CREATE TABLE IF NOT EXISTS stacks (
+			id BIGSERIAL PRIMARY KEY,
+			name TEXT NOT NULL UNIQUE,
+			display_name TEXT NOT NULL
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_pg_stacks_name ON stacks(name)`,
+		`CREATE TABLE IF NOT EXISTS categories (
+			id BIGSERIAL PRIMARY KEY,
+			name TEXT NOT NULL UNIQUE,
+			display_name TEXT NOT NULL
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_pg_categories_name ON categories(name)`,
+		`CREATE TABLE IF NOT EXISTS skill_stacks (
+			skill_id BIGINT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+			stack_id BIGINT NOT NULL REFERENCES stacks(id) ON DELETE CASCADE,
+			PRIMARY KEY (skill_id, stack_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_skill_stacks_stack ON skill_stacks(stack_id)`,
+		`CREATE TABLE IF NOT EXISTS skill_categories (
+			skill_id BIGINT NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+			category_id BIGINT NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+			PRIMARY KEY (skill_id, category_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_skill_categories_category ON skill_categories(category_id)`,
+		`CREATE TABLE IF NOT EXISTS skill_versions (
+			id BIGSERIAL PRIMARY KEY,
+			skill_id BIGINT NOT NULL REFERENCES skills(id),
+			version INTEGER NOT NULL,
+			content TEXT NOT NULL,
+			compact_rules TEXT NOT NULL DEFAULT '',
+			changed_by TEXT NOT NULL DEFAULT 'system',
+			created_at TEXT NOT NULL DEFAULT to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS')
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_pg_skill_versions_skill_version_unique ON skill_versions(skill_id, version)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_skill_versions_skill ON skill_versions(skill_id, version DESC)`,
+		`CREATE TABLE IF NOT EXISTS users (
+			id BIGSERIAL PRIMARY KEY,
+			email TEXT NOT NULL UNIQUE,
+			name TEXT NOT NULL DEFAULT '',
+			role TEXT NOT NULL DEFAULT 'viewer',
+			avatar_url TEXT NOT NULL DEFAULT '',
+			provider TEXT NOT NULL DEFAULT '',
+			created_at TEXT NOT NULL DEFAULT to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS'),
+			updated_at TEXT NOT NULL DEFAULT to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS')
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_pg_users_email ON users(email)`,
+		`CREATE INDEX IF NOT EXISTS idx_pg_users_role ON users(role)`,
 	}
 
 	for _, statement := range statements {
@@ -159,6 +222,15 @@ func observationSearchVectorExpression() string {
 		"setweight(to_tsvector('simple', COALESCE(type, '')), 'B')",
 		"setweight(to_tsvector('simple', COALESCE(tool_name, '')), 'B')",
 		"setweight(to_tsvector('simple', COALESCE(project, '')), 'B')",
+		"setweight(to_tsvector('simple', COALESCE(content, '')), 'C')",
+	}, " || ")
+}
+
+func skillSearchVectorExpression() string {
+	return strings.Join([]string{
+		"setweight(to_tsvector('simple', COALESCE(name, '')), 'A')",
+		"setweight(to_tsvector('simple', COALESCE(display_name, '')), 'A')",
+		"setweight(to_tsvector('simple', COALESCE(triggers, '')), 'B')",
 		"setweight(to_tsvector('simple', COALESCE(content, '')), 'C')",
 	}, " || ")
 }

--- a/internal/store/backend/postgres/postgres_test.go
+++ b/internal/store/backend/postgres/postgres_test.go
@@ -83,6 +83,17 @@ func TestOpenDatabaseBootstrapsIdempotently(t *testing.T) {
 	statements := strings.Join(stubExecutedStatements(name), "\n")
 	for _, needle := range []string{
 		"idx_pg_obs_search_vector",
+		"CREATE TABLE IF NOT EXISTS skills",
+		"CREATE TABLE IF NOT EXISTS stacks",
+		"CREATE TABLE IF NOT EXISTS categories",
+		"CREATE TABLE IF NOT EXISTS skill_stacks",
+		"CREATE TABLE IF NOT EXISTS skill_categories",
+		"CREATE TABLE IF NOT EXISTS skill_versions",
+		"CREATE TABLE IF NOT EXISTS users",
+		"idx_pg_skills_search_vector",
+		"idx_pg_skill_versions_skill_version_unique",
+		"idx_pg_skill_versions_skill",
+		"idx_pg_users_role",
 		"to_tsvector('simple'",
 		"setweight(",
 		"USING GIN",

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	postgresbackend "github.com/alferio94/lore/internal/store/backend/postgres"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
 )
@@ -81,14 +84,52 @@ func TestPostgresStoreBootstrapAndPingIntegration(t *testing.T) {
 		t.Fatalf("Ping() error = %v", err)
 	}
 
-	for _, table := range []string{"sessions", "observations", "sync_state", "sync_mutations"} {
-		var exists bool
-		if err := s.db.QueryRow(`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = $1)`, table).Scan(&exists); err != nil {
-			t.Fatalf("check table %s: %v", table, err)
-		}
-		if !exists {
-			t.Fatalf("expected table %s to exist", table)
-		}
+	if _, err := s.db.Exec(`INSERT INTO sessions (id, project, directory) VALUES ($1, $2, $3)`, "bootstrap-existing", "Lore", "/tmp/lore"); err != nil {
+		t.Fatalf("seed existing runtime row: %v", err)
+	}
+
+	if err := postgresbackend.Bootstrap(s.db); err != nil {
+		t.Fatalf("Bootstrap() rerun error = %v", err)
+	}
+
+	for _, table := range []string{"sessions", "observations", "sync_state", "sync_mutations", "skills", "stacks", "categories", "skill_stacks", "skill_categories", "skill_versions", "users"} {
+		assertPostgresTableExists(t, s.db, table)
+	}
+
+	for _, index := range []string{"idx_pg_obs_search_vector", "idx_pg_skills_name", "idx_pg_skills_active", "idx_pg_stacks_name", "idx_pg_categories_name", "idx_pg_skill_stacks_stack", "idx_pg_skill_categories_category", "idx_pg_skill_versions_skill", "idx_pg_users_email", "idx_pg_users_role", "idx_pg_skills_search_vector"} {
+		assertPostgresIndexExists(t, s.db, index)
+	}
+
+	var project string
+	if err := s.db.QueryRow(`SELECT project FROM sessions WHERE id = $1`, "bootstrap-existing").Scan(&project); err != nil {
+		t.Fatalf("load seeded runtime row: %v", err)
+	}
+	if project != "Lore" {
+		t.Fatalf("seeded runtime row project = %q, want Lore", project)
+	}
+}
+
+func assertPostgresTableExists(t *testing.T, db *sql.DB, table string) {
+	t.Helper()
+
+	var exists bool
+	if err := db.QueryRow(`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = $1)`, table).Scan(&exists); err != nil {
+		t.Fatalf("check table %s: %v", table, err)
+	}
+	if !exists {
+		t.Fatalf("expected table %s to exist", table)
+	}
+}
+
+func assertPostgresIndexExists(t *testing.T, db *sql.DB, index string) {
+	t.Helper()
+
+	var exists bool
+	if err := db.QueryRow(`SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = $1)`, index).Scan(&exists); err != nil {
+		t.Fatalf("check index %s: %v", index, err)
+	}
+	if !exists {
+		t.Fatalf("expected index %s to exist", index)
 	}
 }
 
@@ -519,6 +560,347 @@ func TestSearchParityAllowsBackendRankVariance(t *testing.T) {
 				t.Fatalf("expected remaining results to include %q, got %+v", title, results)
 			}
 		}
+	}
+}
+
+func TestPostgresStoreUserLifecycleIntegration(t *testing.T) {
+	s := newPostgresTestStore(t)
+
+	first, err := s.UpsertUser("first@example.com", "First", "https://example.com/first.png", "google")
+	if err != nil {
+		t.Fatalf("UpsertUser(first): %v", err)
+	}
+	if first.Role != "admin" {
+		t.Fatalf("first role = %q, want admin", first.Role)
+	}
+
+	second, err := s.UpsertUser("second@example.com", "Second", "", "github")
+	if err != nil {
+		t.Fatalf("UpsertUser(second): %v", err)
+	}
+	if second.Role != "viewer" {
+		t.Fatalf("second role = %q, want viewer", second.Role)
+	}
+
+	promoted, err := s.UpdateUserRole(second.ID, "tech_lead")
+	if err != nil {
+		t.Fatalf("UpdateUserRole(second): %v", err)
+	}
+	if promoted.Role != "tech_lead" {
+		t.Fatalf("promoted role = %q, want tech_lead", promoted.Role)
+	}
+
+	relogin, err := s.UpsertUser("second@example.com", "Second Renamed", "https://example.com/second.png", "github")
+	if err != nil {
+		t.Fatalf("UpsertUser(relogin): %v", err)
+	}
+	if relogin.ID != second.ID {
+		t.Fatalf("relogin id = %d, want %d", relogin.ID, second.ID)
+	}
+	if relogin.Role != "tech_lead" {
+		t.Fatalf("relogin role = %q, want tech_lead", relogin.Role)
+	}
+	if relogin.Name != "Second Renamed" {
+		t.Fatalf("relogin name = %q, want Second Renamed", relogin.Name)
+	}
+	if relogin.AvatarURL != "https://example.com/second.png" {
+		t.Fatalf("relogin avatar = %q, want updated avatar", relogin.AvatarURL)
+	}
+
+	users, err := s.ListUsers()
+	if err != nil {
+		t.Fatalf("ListUsers(): %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("ListUsers len = %d, want 2", len(users))
+	}
+	if users[0].Email != "first@example.com" || users[1].Email != "second@example.com" {
+		t.Fatalf("ListUsers order = %+v, want first then second", users)
+	}
+
+	if _, err := s.UpdateUserRole(99999, "admin"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("UpdateUserRole(missing) error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestPostgresStoreUpsertUserAssignsSingleAdminConcurrently(t *testing.T) {
+	s := newPostgresTestStore(t)
+
+	const totalUsers = 12
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, totalUsers)
+
+	for i := 0; i < totalUsers; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := s.UpsertUser(fmt.Sprintf("concurrent-%02d@example.com", i), fmt.Sprintf("User %02d", i), "", "test")
+			errs <- err
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("UpsertUser concurrent error: %v", err)
+		}
+	}
+
+	users, err := s.ListUsers()
+	if err != nil {
+		t.Fatalf("ListUsers(): %v", err)
+	}
+	if len(users) != totalUsers {
+		t.Fatalf("ListUsers len = %d, want %d", len(users), totalUsers)
+	}
+
+	adminCount := 0
+	for _, user := range users {
+		if user.Role == "admin" {
+			adminCount++
+		}
+	}
+	if adminCount != 1 {
+		t.Fatalf("admin user count = %d, want 1; users=%+v", adminCount, users)
+	}
+}
+
+func TestPostgresStoreStatsAndSearchParityIntegration(t *testing.T) {
+	s := newPostgresTestStore(t)
+	now := time.Now().UTC()
+
+	if err := s.CreateSession("stats-recent", "Lore", "/tmp/lore"); err != nil {
+		t.Fatalf("CreateSession(stats-recent): %v", err)
+	}
+	if err := s.CreateSession("stats-old", "Lore", "/tmp/lore-old"); err != nil {
+		t.Fatalf("CreateSession(stats-old): %v", err)
+	}
+	if _, err := s.db.Exec(`UPDATE sessions SET started_at = $1 WHERE id = $2`, now.Add(-8*24*time.Hour).Format("2006-01-02 15:04:05"), "stats-old"); err != nil {
+		t.Fatalf("age old session: %v", err)
+	}
+
+	stack, err := s.CreateStack("go", "Go")
+	if err != nil {
+		t.Fatalf("CreateStack(): %v", err)
+	}
+	category, err := s.CreateCategory("backend", "Backend")
+	if err != nil {
+		t.Fatalf("CreateCategory(): %v", err)
+	}
+
+	created, err := s.CreateSkill(CreateSkillParams{
+		Name:         "postgres-search",
+		DisplayName:  "Postgres Search",
+		StackIDs:     []int64{stack.ID},
+		CategoryIDs:  []int64{category.ID},
+		Triggers:     "postgres search parity",
+		Content:      "Search inclusion over postgres content",
+		CompactRules: "Prefer deterministic inclusion checks",
+		ChangedBy:    "slice-c",
+	})
+	if err != nil {
+		t.Fatalf("CreateSkill(): %v", err)
+	}
+	if _, err := s.CreateSkill(CreateSkillParams{
+		Name:         "inactive-skill",
+		DisplayName:  "Inactive Skill",
+		Triggers:     "archived",
+		Content:      "should disappear from active lists",
+		CompactRules: "",
+		ChangedBy:    "slice-c",
+	}); err != nil {
+		t.Fatalf("CreateSkill(inactive): %v", err)
+	}
+	if err := s.DeleteSkill("inactive-skill", "slice-c"); err != nil {
+		t.Fatalf("DeleteSkill(inactive): %v", err)
+	}
+
+	updatedContent := "Search inclusion over postgres content and admin stats"
+	updatedRules := "Prefer inclusion/filter checks over rank lockstep"
+	updated, err := s.UpdateSkill("postgres-search", UpdateSkillParams{
+		Content:      &updatedContent,
+		CompactRules: &updatedRules,
+		ChangedBy:    "slice-c",
+	})
+	if err != nil {
+		t.Fatalf("UpdateSkill(): %v", err)
+	}
+	if updated.Version != 2 {
+		t.Fatalf("updated version = %d, want 2", updated.Version)
+	}
+
+	var versions int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM skill_versions WHERE skill_id = $1`, created.ID).Scan(&versions); err != nil {
+		t.Fatalf("count skill_versions: %v", err)
+	}
+	if versions != 2 {
+		t.Fatalf("skill_versions count = %d, want 2", versions)
+	}
+
+	searchResults, err := s.ListSkills(ListSkillsParams{Query: "postgres admin stats"})
+	if err != nil {
+		t.Fatalf("ListSkills(search): %v", err)
+	}
+	if len(searchResults) != 1 || searchResults[0].Name != "postgres-search" {
+		t.Fatalf("ListSkills(search) = %+v, want only postgres-search", searchResults)
+	}
+
+	if err := s.DeleteStack(stack.ID); err != nil {
+		t.Fatalf("DeleteStack(): %v", err)
+	}
+	if err := s.DeleteCategory(category.ID); err != nil {
+		t.Fatalf("DeleteCategory(): %v", err)
+	}
+
+	reloaded, err := s.GetSkill("postgres-search")
+	if err != nil {
+		t.Fatalf("GetSkill(after cascades): %v", err)
+	}
+	if len(reloaded.Stacks) != 0 || len(reloaded.Categories) != 0 {
+		t.Fatalf("GetSkill relationships after cascades = stacks:%+v categories:%+v, want both empty", reloaded.Stacks, reloaded.Categories)
+	}
+
+	obsID, err := s.AddObservation(AddObservationParams{
+		SessionID: "stats-recent",
+		Type:      "decision",
+		Title:     "fresh",
+		Content:   "fresh content",
+		Project:   "Lore",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("AddObservation(fresh): %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "stats-recent",
+		Type:      "decision",
+		Title:     "active project",
+		Content:   "counts toward stats",
+		Project:   "Lore-Admin",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("AddObservation(second project): %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "stats-old",
+		Type:      "decision",
+		Title:     "old observation",
+		Content:   "should fall out of weekly count",
+		Project:   "Lore",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("AddObservation(old): %v", err)
+	}
+	if _, err := s.db.Exec(`UPDATE observations SET created_at = $1, updated_at = $1 WHERE title = $2`, now.Add(-8*24*time.Hour).Format("2006-01-02 15:04:05"), "old observation"); err != nil {
+		t.Fatalf("age old observation: %v", err)
+	}
+	if err := s.DeleteObservation(obsID, false); err != nil {
+		t.Fatalf("DeleteObservation(fresh): %v", err)
+	}
+
+	stats, err := s.AdminStats()
+	if err != nil {
+		t.Fatalf("AdminStats(): %v", err)
+	}
+	if stats.ActiveProjects != 2 {
+		t.Fatalf("ActiveProjects = %d, want 2", stats.ActiveProjects)
+	}
+	if stats.ActiveSkills != 1 {
+		t.Fatalf("ActiveSkills = %d, want 1", stats.ActiveSkills)
+	}
+	if stats.ObservationsThisWeek != 1 {
+		t.Fatalf("ObservationsThisWeek = %d, want 1", stats.ObservationsThisWeek)
+	}
+	if stats.SessionsThisWeek != 1 {
+		t.Fatalf("SessionsThisWeek = %d, want 1", stats.SessionsThisWeek)
+	}
+
+	if err := s.DeleteSkill("postgres-search", "slice-c"); err != nil {
+		t.Fatalf("DeleteSkill(postgres-search): %v", err)
+	}
+	searchResults, err = s.ListSkills(ListSkillsParams{Query: "postgres admin stats"})
+	if err != nil {
+		t.Fatalf("ListSkills(search after delete): %v", err)
+	}
+	if len(searchResults) != 0 {
+		t.Fatalf("ListSkills(search after delete) = %+v, want empty", searchResults)
+	}
+
+	var isActive bool
+	if err := s.db.QueryRow(`SELECT is_active FROM skills WHERE name = $1`, "postgres-search").Scan(&isActive); err != nil {
+		t.Fatalf("load soft-deleted skill row: %v", err)
+	}
+	if isActive {
+		t.Fatal("expected soft-deleted skill row to remain with is_active=false")
+	}
+}
+
+func TestPostgresStoreUpdateSkillSerializesConcurrentVersionHistory(t *testing.T) {
+	s := newPostgresTestStore(t)
+
+	created, err := s.CreateSkill(CreateSkillParams{
+		Name:         "concurrent-version-skill",
+		DisplayName:  "Concurrent Version Skill",
+		Triggers:     "concurrent update",
+		Content:      "initial content",
+		CompactRules: "initial rules",
+		ChangedBy:    "test",
+	})
+	if err != nil {
+		t.Fatalf("CreateSkill(): %v", err)
+	}
+
+	const updates = 10
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, updates)
+
+	for i := 0; i < updates; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			content := fmt.Sprintf("updated content %02d", i)
+			_, err := s.UpdateSkill("concurrent-version-skill", UpdateSkillParams{
+				Content:   &content,
+				ChangedBy: "test",
+			})
+			errs <- err
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("UpdateSkill concurrent error: %v", err)
+		}
+	}
+
+	reloaded, err := s.GetSkill("concurrent-version-skill")
+	if err != nil {
+		t.Fatalf("GetSkill(): %v", err)
+	}
+	if reloaded.Version != updates+1 {
+		t.Fatalf("skill version = %d, want %d", reloaded.Version, updates+1)
+	}
+
+	var versionRows int
+	var distinctVersions int
+	if err := s.db.QueryRow(`SELECT COUNT(*), COUNT(DISTINCT version) FROM skill_versions WHERE skill_id = $1`, created.ID).Scan(&versionRows, &distinctVersions); err != nil {
+		t.Fatalf("count skill_versions: %v", err)
+	}
+	if versionRows != updates+1 || distinctVersions != updates+1 {
+		t.Fatalf("skill_versions rows=%d distinct_versions=%d, want %d", versionRows, distinctVersions, updates+1)
 	}
 }
 

--- a/internal/store/postgres_store.go
+++ b/internal/store/postgres_store.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
+	"unicode"
 
 	postgresbackend "github.com/alferio94/lore/internal/store/backend/postgres"
+	"github.com/lib/pq"
 )
 
 type PostgresStore struct {
@@ -588,38 +591,676 @@ func (s *PostgresStore) PruneProject(string) (*PruneResult, error) {
 func (s *PostgresStore) MergeProjects([]string, string) (*MergeResult, error) {
 	return nil, s.unsupported("project merge")
 }
-func (s *PostgresStore) ListSkills(ListSkillsParams) ([]Skill, error) {
-	return nil, s.unsupported("skills catalog")
+
+func (s *PostgresStore) loadSkillRelationships(db queryer, skillID int64) ([]StackRef, []CategoryRef, error) {
+	stackRows, err := db.Query(`
+		SELECT st.id, st.name, st.display_name
+		FROM skill_stacks ss
+		JOIN stacks st ON st.id = ss.stack_id
+		WHERE ss.skill_id = $1
+		ORDER BY st.name ASC
+	`, skillID)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer stackRows.Close()
+
+	stacks := make([]StackRef, 0)
+	for stackRows.Next() {
+		var ref StackRef
+		if err := stackRows.Scan(&ref.ID, &ref.Name, &ref.DisplayName); err != nil {
+			return nil, nil, err
+		}
+		stacks = append(stacks, ref)
+	}
+	if err := stackRows.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	categoryRows, err := db.Query(`
+		SELECT c.id, c.name, c.display_name
+		FROM skill_categories sc
+		JOIN categories c ON c.id = sc.category_id
+		WHERE sc.skill_id = $1
+		ORDER BY c.name ASC
+	`, skillID)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer categoryRows.Close()
+
+	categories := make([]CategoryRef, 0)
+	for categoryRows.Next() {
+		var ref CategoryRef
+		if err := categoryRows.Scan(&ref.ID, &ref.Name, &ref.DisplayName); err != nil {
+			return nil, nil, err
+		}
+		categories = append(categories, ref)
+	}
+	if err := categoryRows.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	return stacks, categories, nil
 }
-func (s *PostgresStore) GetSkill(string) (*Skill, error) { return nil, s.unsupported("skills catalog") }
-func (s *PostgresStore) CreateSkill(CreateSkillParams) (*Skill, error) {
-	return nil, s.unsupported("skills catalog")
+
+func postgresSkillSearchVector(alias string) string {
+	qualify := func(column string) string {
+		if alias == "" {
+			return column
+		}
+		return alias + "." + column
+	}
+
+	return strings.Join([]string{
+		fmt.Sprintf("setweight(to_tsvector('simple', COALESCE(%s, '')), 'A')", qualify("name")),
+		fmt.Sprintf("setweight(to_tsvector('simple', COALESCE(%s, '')), 'A')", qualify("display_name")),
+		fmt.Sprintf("setweight(to_tsvector('simple', COALESCE(%s, '')), 'B')", qualify("triggers")),
+		fmt.Sprintf("setweight(to_tsvector('simple', COALESCE(%s, '')), 'C')", qualify("content")),
+	}, " || ")
 }
-func (s *PostgresStore) UpdateSkill(string, UpdateSkillParams) (*Skill, error) {
-	return nil, s.unsupported("skills catalog")
+
+func postgresSkillSearchQuery(query string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		switch {
+		case unicode.IsLetter(r), unicode.IsNumber(r):
+			return r
+		case strings.ContainsRune("-_./#+", r):
+			return r
+		default:
+			return ' '
+		}
+	}, query)
+
+	tokens := make([]string, 0)
+	for _, token := range strings.Fields(cleaned) {
+		tokens = append(tokens, `"`+strings.Trim(token, `"'`)+`"`)
+	}
+	return strings.Join(tokens, " ")
 }
-func (s *PostgresStore) DeleteSkill(string, string) error { return s.unsupported("skills catalog") }
-func (s *PostgresStore) ListStacks() ([]Stack, error)     { return nil, s.unsupported("stack catalog") }
-func (s *PostgresStore) CreateStack(string, string) (*Stack, error) {
-	return nil, s.unsupported("stack catalog")
+
+func normalizePostgresCatalogError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) && string(pqErr.Code) == "23505" {
+		if constraint := strings.TrimSpace(pqErr.Constraint); constraint != "" {
+			return fmt.Errorf("UNIQUE constraint failed: %s", constraint)
+		}
+		return fmt.Errorf("UNIQUE constraint failed")
+	}
+
+	upper := strings.ToUpper(err.Error())
+	if strings.Contains(upper, "DUPLICATE KEY VALUE") || strings.Contains(upper, "UNIQUE") {
+		return fmt.Errorf("UNIQUE constraint failed: %w", err)
+	}
+
+	return err
 }
-func (s *PostgresStore) DeleteStack(int64) error { return s.unsupported("stack catalog") }
+
+func scanSkill(scanner interface{ Scan(dest ...any) error }, skill *Skill) error {
+	return scanner.Scan(
+		&skill.ID,
+		&skill.Name,
+		&skill.DisplayName,
+		&skill.Triggers,
+		&skill.Content,
+		&skill.CompactRules,
+		&skill.Version,
+		&skill.IsActive,
+		&skill.ChangedBy,
+		&skill.CreatedAt,
+		&skill.UpdatedAt,
+	)
+}
+
+func (s *PostgresStore) getSkillByID(db queryer, id int64, metadataOnly bool) (*Skill, error) {
+	contentExpr := "content"
+	rulesExpr := "compact_rules"
+	if metadataOnly {
+		contentExpr = `'' AS content`
+		rulesExpr = `'' AS compact_rules`
+	}
+
+	rows, err := db.Query(fmt.Sprintf(`
+		SELECT id, name, display_name, triggers, %s, %s, version, is_active, changed_by, created_at, updated_at
+		FROM skills
+		WHERE id = $1
+	`, contentExpr, rulesExpr), id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		return nil, sql.ErrNoRows
+	}
+
+	var skill Skill
+	if err := scanSkill(rows, &skill); err != nil {
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	stacks, categories, err := s.loadSkillRelationships(db, skill.ID)
+	if err != nil {
+		return nil, err
+	}
+	skill.Stacks = stacks
+	skill.Categories = categories
+	return &skill, nil
+}
+
+func (s *PostgresStore) getSkillByName(db queryer, name string, metadataOnly bool) (*Skill, error) {
+	rows, err := db.Query(`SELECT id FROM skills WHERE name = $1`, name)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		return nil, sql.ErrNoRows
+	}
+	var id int64
+	if err := rows.Scan(&id); err != nil {
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	return s.getSkillByID(db, id, metadataOnly)
+}
+
+func insertSkillRelationshipsTx(tx *sql.Tx, skillID int64, stackIDs, categoryIDs []int64) error {
+	for _, stackID := range stackIDs {
+		if _, err := tx.Exec(`INSERT INTO skill_stacks (skill_id, stack_id) VALUES ($1, $2)`, skillID, stackID); err != nil {
+			return err
+		}
+	}
+	for _, categoryID := range categoryIDs {
+		if _, err := tx.Exec(`INSERT INTO skill_categories (skill_id, category_id) VALUES ($1, $2)`, skillID, categoryID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeSkillVersionTx(tx *sql.Tx, skillID int64, version int, content, compactRules, changedBy string) error {
+	_, err := tx.Exec(`
+		INSERT INTO skill_versions (skill_id, version, content, compact_rules, changed_by)
+		VALUES ($1, $2, $3, $4, $5)
+	`, skillID, version, content, compactRules, changedBy)
+	return err
+}
+
+func (s *PostgresStore) ListSkills(params ListSkillsParams) ([]Skill, error) {
+	args := make([]any, 0, 3)
+	baseQuery := `
+		SELECT sk.id, sk.name, sk.display_name, sk.triggers, '' AS content, '' AS compact_rules,
+		       sk.version, sk.is_active, sk.changed_by, sk.created_at, sk.updated_at
+		FROM skills sk
+	`
+	where := []string{"sk.is_active = TRUE"}
+	orderBy := "ORDER BY sk.name ASC"
+
+	if params.Query != "" {
+		searchQuery := postgresSkillSearchQuery(params.Query)
+		if searchQuery == "" {
+			return []Skill{}, nil
+		}
+		vector := postgresSkillSearchVector("sk")
+		args = append(args, searchQuery)
+		baseQuery = fmt.Sprintf(`
+			SELECT sk.id, sk.name, sk.display_name, sk.triggers, '' AS content, '' AS compact_rules,
+			       sk.version, sk.is_active, sk.changed_by, sk.created_at, sk.updated_at,
+			       ts_rank_cd(%s, websearch_to_tsquery('simple', $1)) AS rank
+			FROM skills sk
+		`, vector)
+		where = append(where, fmt.Sprintf(`%s @@ websearch_to_tsquery('simple', $1)`, vector))
+		orderBy = "ORDER BY rank DESC, sk.name ASC"
+	}
+
+	if params.StackID != nil {
+		args = append(args, *params.StackID)
+		where = append(where, fmt.Sprintf("sk.id IN (SELECT skill_id FROM skill_stacks WHERE stack_id = $%d)", len(args)))
+	}
+	if params.CategoryID != nil {
+		args = append(args, *params.CategoryID)
+		where = append(where, fmt.Sprintf("sk.id IN (SELECT skill_id FROM skill_categories WHERE category_id = $%d)", len(args)))
+	}
+
+	rows, err := s.db.Query(baseQuery+" WHERE "+strings.Join(where, " AND ")+" "+orderBy, args...)
+	if err != nil {
+		return nil, normalizePostgresCatalogError(err)
+	}
+	defer rows.Close()
+
+	results := make([]Skill, 0)
+	for rows.Next() {
+		var skill Skill
+		if params.Query != "" {
+			var rank float64
+			if err := rows.Scan(&skill.ID, &skill.Name, &skill.DisplayName, &skill.Triggers, &skill.Content, &skill.CompactRules, &skill.Version, &skill.IsActive, &skill.ChangedBy, &skill.CreatedAt, &skill.UpdatedAt, &rank); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := scanSkill(rows, &skill); err != nil {
+				return nil, err
+			}
+		}
+		stacks, categories, err := s.loadSkillRelationships(s.db, skill.ID)
+		if err != nil {
+			return nil, err
+		}
+		skill.Stacks = stacks
+		skill.Categories = categories
+		results = append(results, skill)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (s *PostgresStore) GetSkill(name string) (*Skill, error) {
+	return s.getSkillByName(s.db, name, false)
+}
+
+func (s *PostgresStore) CreateSkill(params CreateSkillParams) (*Skill, error) {
+	changedBy := params.ChangedBy
+	if changedBy == "" {
+		changedBy = "system"
+	}
+
+	var created *Skill
+	err := s.withTx(func(tx *sql.Tx) error {
+		var skillID int64
+		if err := tx.QueryRow(`
+			INSERT INTO skills (name, display_name, triggers, content, compact_rules, version, is_active, changed_by)
+			VALUES ($1, $2, $3, $4, $5, 1, TRUE, $6)
+			RETURNING id
+		`, params.Name, params.DisplayName, params.Triggers, params.Content, params.CompactRules, changedBy).Scan(&skillID); err != nil {
+			return normalizePostgresCatalogError(err)
+		}
+
+		if err := insertSkillRelationshipsTx(tx, skillID, params.StackIDs, params.CategoryIDs); err != nil {
+			return normalizePostgresCatalogError(err)
+		}
+		if err := writeSkillVersionTx(tx, skillID, 1, params.Content, params.CompactRules, changedBy); err != nil {
+			return normalizePostgresCatalogError(err)
+		}
+
+		skill, err := s.getSkillByID(tx, skillID, false)
+		if err != nil {
+			return err
+		}
+		created = skill
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return created, nil
+}
+
+func (s *PostgresStore) UpdateSkill(name string, params UpdateSkillParams) (*Skill, error) {
+	changedBy := params.ChangedBy
+	if changedBy == "" {
+		changedBy = "system"
+	}
+
+	var updated *Skill
+	err := s.withTx(func(tx *sql.Tx) error {
+		var skillID int64
+		var currentVersion int
+		if err := tx.QueryRow(`SELECT id, version FROM skills WHERE name = $1 FOR UPDATE`, name).Scan(&skillID, &currentVersion); err != nil {
+			return err
+		}
+
+		newVersion := currentVersion + 1
+		setClauses := []string{"version = $1", "changed_by = $2", "updated_at = to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS')"}
+		args := []any{newVersion, changedBy}
+		placeholder := 3
+
+		if params.DisplayName != nil {
+			setClauses = append(setClauses, fmt.Sprintf("display_name = $%d", placeholder))
+			args = append(args, *params.DisplayName)
+			placeholder++
+		}
+		if params.Triggers != nil {
+			setClauses = append(setClauses, fmt.Sprintf("triggers = $%d", placeholder))
+			args = append(args, *params.Triggers)
+			placeholder++
+		}
+		if params.Content != nil {
+			setClauses = append(setClauses, fmt.Sprintf("content = $%d", placeholder))
+			args = append(args, *params.Content)
+			placeholder++
+		}
+		if params.CompactRules != nil {
+			setClauses = append(setClauses, fmt.Sprintf("compact_rules = $%d", placeholder))
+			args = append(args, *params.CompactRules)
+			placeholder++
+		}
+		args = append(args, skillID)
+
+		if _, err := tx.Exec("UPDATE skills SET "+strings.Join(setClauses, ", ")+fmt.Sprintf(" WHERE id = $%d", placeholder), args...); err != nil {
+			return normalizePostgresCatalogError(err)
+		}
+
+		if params.StackIDs != nil {
+			if _, err := tx.Exec(`DELETE FROM skill_stacks WHERE skill_id = $1`, skillID); err != nil {
+				return err
+			}
+			if err := insertSkillRelationshipsTx(tx, skillID, *params.StackIDs, nil); err != nil {
+				return normalizePostgresCatalogError(err)
+			}
+		}
+		if params.CategoryIDs != nil {
+			if _, err := tx.Exec(`DELETE FROM skill_categories WHERE skill_id = $1`, skillID); err != nil {
+				return err
+			}
+			if err := insertSkillRelationshipsTx(tx, skillID, nil, *params.CategoryIDs); err != nil {
+				return normalizePostgresCatalogError(err)
+			}
+		}
+
+		var content string
+		var compactRules string
+		if err := tx.QueryRow(`SELECT content, compact_rules FROM skills WHERE id = $1`, skillID).Scan(&content, &compactRules); err != nil {
+			return err
+		}
+		if err := writeSkillVersionTx(tx, skillID, newVersion, content, compactRules, changedBy); err != nil {
+			return normalizePostgresCatalogError(err)
+		}
+
+		skill, err := s.getSkillByID(tx, skillID, false)
+		if err != nil {
+			return err
+		}
+		updated = skill
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func (s *PostgresStore) DeleteSkill(name, changedBy string) error {
+	if changedBy == "" {
+		changedBy = "system"
+	}
+	result, err := s.db.Exec(`
+		UPDATE skills
+		SET is_active = FALSE, changed_by = $1, updated_at = to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS')
+		WHERE name = $2
+	`, changedBy, name)
+	if err != nil {
+		return normalizePostgresCatalogError(err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *PostgresStore) ListStacks() ([]Stack, error) {
+	rows, err := s.db.Query(`SELECT id, name, display_name FROM stacks ORDER BY name ASC`)
+	if err != nil {
+		return nil, normalizePostgresCatalogError(err)
+	}
+	defer rows.Close()
+
+	results := make([]Stack, 0)
+	for rows.Next() {
+		var stack Stack
+		if err := rows.Scan(&stack.ID, &stack.Name, &stack.DisplayName); err != nil {
+			return nil, err
+		}
+		results = append(results, stack)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (s *PostgresStore) CreateStack(name, displayName string) (*Stack, error) {
+	var id int64
+	if err := s.db.QueryRow(`INSERT INTO stacks (name, display_name) VALUES ($1, $2) RETURNING id`, name, displayName).Scan(&id); err != nil {
+		if normalized := normalizePostgresCatalogError(err); normalized != err {
+			return nil, normalized
+		}
+		result, execErr := s.db.Exec(`INSERT INTO stacks (name, display_name) VALUES ($1, $2)`, name, displayName)
+		if execErr != nil {
+			return nil, normalizePostgresCatalogError(execErr)
+		}
+		id, err = result.LastInsertId()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Stack{ID: id, Name: name, DisplayName: displayName}, nil
+}
+
+func (s *PostgresStore) DeleteStack(id int64) error {
+	result, err := s.db.Exec(`DELETE FROM stacks WHERE id = $1`, id)
+	if err != nil {
+		return normalizePostgresCatalogError(err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *PostgresStore) ListCategories() ([]Category, error) {
-	return nil, s.unsupported("category catalog")
+	rows, err := s.db.Query(`SELECT id, name, display_name FROM categories ORDER BY name ASC`)
+	if err != nil {
+		return nil, normalizePostgresCatalogError(err)
+	}
+	defer rows.Close()
+
+	results := make([]Category, 0)
+	for rows.Next() {
+		var category Category
+		if err := rows.Scan(&category.ID, &category.Name, &category.DisplayName); err != nil {
+			return nil, err
+		}
+		results = append(results, category)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
 }
-func (s *PostgresStore) CreateCategory(string, string) (*Category, error) {
-	return nil, s.unsupported("category catalog")
+
+func (s *PostgresStore) CreateCategory(name, displayName string) (*Category, error) {
+	var id int64
+	if err := s.db.QueryRow(`INSERT INTO categories (name, display_name) VALUES ($1, $2) RETURNING id`, name, displayName).Scan(&id); err != nil {
+		if normalized := normalizePostgresCatalogError(err); normalized != err {
+			return nil, normalized
+		}
+		result, execErr := s.db.Exec(`INSERT INTO categories (name, display_name) VALUES ($1, $2)`, name, displayName)
+		if execErr != nil {
+			return nil, normalizePostgresCatalogError(execErr)
+		}
+		id, err = result.LastInsertId()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Category{ID: id, Name: name, DisplayName: displayName}, nil
 }
-func (s *PostgresStore) DeleteCategory(int64) error { return s.unsupported("category catalog") }
+
+func (s *PostgresStore) DeleteCategory(id int64) error {
+	result, err := s.db.Exec(`DELETE FROM categories WHERE id = $1`, id)
+	if err != nil {
+		return normalizePostgresCatalogError(err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *PostgresStore) AdminStats() (AdminStats, error) {
-	return AdminStats{}, s.unsupported("admin stats")
+	var stats AdminStats
+	var firstErr error
+
+	if err := s.db.QueryRow(
+		`SELECT COUNT(DISTINCT project) FROM observations WHERE project IS NOT NULL AND deleted_at IS NULL`,
+	).Scan(&stats.ActiveProjects); err != nil && firstErr == nil {
+		firstErr = err
+	}
+
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM skills WHERE is_active = TRUE`,
+	).Scan(&stats.ActiveSkills); err != nil && firstErr == nil {
+		firstErr = err
+	}
+
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM observations WHERE deleted_at IS NULL AND created_at >= to_char(timezone('UTC', now()) - interval '7 days', 'YYYY-MM-DD HH24:MI:SS')`,
+	).Scan(&stats.ObservationsThisWeek); err != nil && firstErr == nil {
+		firstErr = err
+	}
+
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE started_at >= to_char(timezone('UTC', now()) - interval '7 days', 'YYYY-MM-DD HH24:MI:SS')`,
+	).Scan(&stats.SessionsThisWeek); err != nil && firstErr == nil {
+		firstErr = err
+	}
+
+	return stats, firstErr
 }
-func (s *PostgresStore) UpsertUser(string, string, string, string) (*User, error) {
-	return nil, s.unsupported("users")
+
+func (s *PostgresStore) UpsertUser(email, name, avatarURL, provider string) (*User, error) {
+	var user *User
+	err := s.withTx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`LOCK TABLE users IN SHARE ROW EXCLUSIVE MODE`); err != nil {
+			return err
+		}
+
+		var count int
+		if err := tx.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&count); err != nil {
+			return err
+		}
+
+		role := "viewer"
+		if count == 0 {
+			role = "admin"
+		}
+
+		var upserted User
+		if err := tx.QueryRow(`
+			INSERT INTO users (email, name, role, avatar_url, provider)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT(email) DO UPDATE SET
+				name = EXCLUDED.name,
+				avatar_url = EXCLUDED.avatar_url,
+				provider = EXCLUDED.provider,
+				updated_at = to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS')
+			RETURNING id, email, name, role, avatar_url, provider, created_at, updated_at
+		`, email, name, role, avatarURL, provider).Scan(
+			&upserted.ID,
+			&upserted.Email,
+			&upserted.Name,
+			&upserted.Role,
+			&upserted.AvatarURL,
+			&upserted.Provider,
+			&upserted.CreatedAt,
+			&upserted.UpdatedAt,
+		); err != nil {
+			return normalizePostgresCatalogError(err)
+		}
+		user = &upserted
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
 }
-func (s *PostgresStore) ListUsers() ([]User, error) { return nil, s.unsupported("users") }
-func (s *PostgresStore) UpdateUserRole(int64, string) (*User, error) {
-	return nil, s.unsupported("users")
+
+func (s *PostgresStore) ListUsers() ([]User, error) {
+	rows, err := s.db.Query(`
+		SELECT id, email, name, role, avatar_url, provider, created_at, updated_at
+		FROM users
+		ORDER BY created_at ASC
+	`)
+	if err != nil {
+		return nil, normalizePostgresCatalogError(err)
+	}
+	defer rows.Close()
+
+	results := make([]User, 0)
+	for rows.Next() {
+		var user User
+		if err := scanUser(rows, &user); err != nil {
+			return nil, err
+		}
+		results = append(results, user)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (s *PostgresStore) UpdateUserRole(id int64, role string) (*User, error) {
+	var user *User
+	err := s.withTx(func(tx *sql.Tx) error {
+		var updated User
+		err := tx.QueryRow(`
+			UPDATE users
+			SET role = $1, updated_at = to_char(timezone('UTC', now()), 'YYYY-MM-DD HH24:MI:SS')
+			WHERE id = $2
+			RETURNING id, email, name, role, avatar_url, provider, created_at, updated_at
+		`, role, id).Scan(
+			&updated.ID,
+			&updated.Email,
+			&updated.Name,
+			&updated.Role,
+			&updated.AvatarURL,
+			&updated.Provider,
+			&updated.CreatedAt,
+			&updated.UpdatedAt,
+		)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return normalizePostgresCatalogError(err)
+		}
+		user = &updated
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
 }
 
 func (s *PostgresStore) unsupported(feature string) error {
@@ -851,6 +1492,19 @@ func scanObservation(scanner interface{ Scan(dest ...any) error }, o *Observatio
 		&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content,
 		&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt,
 		&o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
+	)
+}
+
+func scanUser(scanner interface{ Scan(dest ...any) error }, user *User) error {
+	return scanner.Scan(
+		&user.ID,
+		&user.Email,
+		&user.Name,
+		&user.Role,
+		&user.AvatarURL,
+		&user.Provider,
+		&user.CreatedAt,
+		&user.UpdatedAt,
 	)
 }
 

--- a/internal/store/postgres_store_test.go
+++ b/internal/store/postgres_store_test.go
@@ -10,9 +10,11 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/lib/pq"
 )
 
-func TestPostgresStoreUnsupportedMethodsReturnExplicitError(t *testing.T) {
+func TestPostgresStoreUnsupportedPromptMethodsReturnExplicitError(t *testing.T) {
 	s := &PostgresStore{cfg: Config{Backend: BackendPostgreSQL}}
 
 	checks := []struct {
@@ -20,7 +22,6 @@ func TestPostgresStoreUnsupportedMethodsReturnExplicitError(t *testing.T) {
 		err  error
 	}{
 		{name: "prompts", err: func() error { _, err := s.AddPrompt(AddPromptParams{}); return err }()},
-		{name: "skills catalog", err: func() error { _, err := s.ListSkills(ListSkillsParams{}); return err }()},
 	}
 
 	for _, tc := range checks {
@@ -37,6 +38,107 @@ func TestPostgresStoreUnsupportedMethodsReturnExplicitError(t *testing.T) {
 		if !strings.Contains(tc.err.Error(), tc.name) {
 			t.Fatalf("%s: error text %q missing feature name", tc.name, tc.err.Error())
 		}
+	}
+}
+
+func TestPostgresSkillSearchQuerySanitizesSpecialCharacters(t *testing.T) {
+	if got := postgresSkillSearchQuery(`"special" OR AND`); got != `"special" "OR" "AND"` {
+		t.Fatalf("postgresSkillSearchQuery() = %q, want %q", got, `"special" "OR" "AND"`)
+	}
+
+	if got := postgresSkillSearchQuery(`!!! (( ))`); got != "" {
+		t.Fatalf("postgresSkillSearchQuery(punctuation-only) = %q, want empty string", got)
+	}
+}
+
+func TestPostgresStoreLoadSkillRelationshipsNormalizesEmptySlices(t *testing.T) {
+	s := newStubPostgresStore(t, Config{Backend: BackendPostgreSQL}, func(query string, _ []driver.NamedValue) (driver.Rows, error) {
+		switch {
+		case strings.Contains(query, "FROM skill_stacks"):
+			return &stubPostgresRows{
+				columns: []string{"id", "name", "display_name"},
+				values:  [][]driver.Value{{int64(3), "go", "Go"}},
+			}, nil
+		case strings.Contains(query, "FROM skill_categories"):
+			return &stubPostgresRows{columns: []string{"id", "name", "display_name"}}, nil
+		default:
+			return &stubPostgresRows{columns: []string{"id"}}, nil
+		}
+	})
+
+	stacks, categories, err := s.loadSkillRelationships(s.db, 42)
+	if err != nil {
+		t.Fatalf("loadSkillRelationships(): %v", err)
+	}
+	if len(stacks) != 1 || stacks[0].Name != "go" {
+		t.Fatalf("stacks = %+v, want one Go stack", stacks)
+	}
+	if categories == nil {
+		t.Fatal("expected empty categories slice, got nil")
+	}
+	if len(categories) != 0 {
+		t.Fatalf("categories len = %d, want 0", len(categories))
+	}
+}
+
+func TestPostgresStoreListSkillsSanitizesSpecialCharacterSearchQuery(t *testing.T) {
+	var capturedQuery string
+	s := newStubPostgresStore(t, Config{Backend: BackendPostgreSQL}, func(query string, args []driver.NamedValue) (driver.Rows, error) {
+		switch {
+		case strings.Contains(query, "ts_rank_cd"):
+			capturedQuery, _ = args[0].Value.(string)
+			return &stubPostgresRows{columns: []string{"id", "name", "display_name", "triggers", "content", "compact_rules", "version", "is_active", "changed_by", "created_at", "updated_at"}}, nil
+		case strings.Contains(query, "FROM skill_stacks") || strings.Contains(query, "FROM skill_categories"):
+			return &stubPostgresRows{columns: []string{"id", "name", "display_name"}}, nil
+		default:
+			return &stubPostgresRows{columns: []string{"id"}}, nil
+		}
+	})
+
+	skills, err := s.ListSkills(ListSkillsParams{Query: `"special" OR AND`})
+	if err != nil {
+		t.Fatalf("ListSkills(): %v", err)
+	}
+	if skills == nil {
+		t.Fatal("expected empty skills slice, got nil")
+	}
+	if capturedQuery != `"special" "OR" "AND"` {
+		t.Fatalf("sanitized query = %q, want %q", capturedQuery, `"special" "OR" "AND"`)
+	}
+}
+
+func TestPostgresStoreCreateStackNormalizesDuplicateKey(t *testing.T) {
+	s := newStubPostgresStoreWithExec(t, Config{Backend: BackendPostgreSQL}, nil, func(query string, _ []driver.NamedValue) (driver.Result, error) {
+		if strings.Contains(query, "INSERT INTO stacks") {
+			return nil, &pq.Error{Code: "23505", Constraint: "stacks_name_key"}
+		}
+		return stubPostgresResult{rowsAffected: 1}, nil
+	})
+
+	_, err := s.CreateStack("go", "Go")
+	if err == nil || !strings.Contains(err.Error(), "UNIQUE") {
+		t.Fatalf("CreateStack() error = %v, want normalized UNIQUE conflict", err)
+	}
+}
+
+func TestPostgresStoreCreateCategoryNormalizesDuplicateKey(t *testing.T) {
+	s := newStubPostgresStoreWithExec(t, Config{Backend: BackendPostgreSQL}, nil, func(query string, _ []driver.NamedValue) (driver.Result, error) {
+		if strings.Contains(query, "INSERT INTO categories") {
+			return nil, &pq.Error{Code: "23505", Constraint: "categories_name_key"}
+		}
+		return stubPostgresResult{rowsAffected: 1}, nil
+	})
+
+	_, err := s.CreateCategory("testing", "Testing")
+	if err == nil || !strings.Contains(err.Error(), "UNIQUE") {
+		t.Fatalf("CreateCategory() error = %v, want normalized UNIQUE conflict", err)
+	}
+}
+
+func TestNormalizePostgresCatalogErrorRecognizesDuplicateKey(t *testing.T) {
+	err := normalizePostgresCatalogError(&pq.Error{Code: "23505", Constraint: "skills_name_key"})
+	if err == nil || !strings.Contains(err.Error(), "UNIQUE") {
+		t.Fatalf("normalizePostgresCatalogError() = %v, want UNIQUE conflict text", err)
 	}
 }
 
@@ -196,15 +298,16 @@ func TestPostgresObservationSearchVectorOmitsAliasPrefixWhenEmpty(t *testing.T) 
 }
 
 var (
-	stubPostgresDriverMu   sync.Mutex
-	stubPostgresDriverSeq  int
-	stubPostgresResponders = map[string]func(query string, args []driver.NamedValue) (driver.Rows, error){}
+	stubPostgresDriverMu       sync.Mutex
+	stubPostgresDriverSeq      int
+	stubPostgresResponders     = map[string]func(query string, args []driver.NamedValue) (driver.Rows, error){}
+	stubPostgresExecResponders = map[string]func(query string, args []driver.NamedValue) (driver.Result, error){}
 )
 
 func newStubPostgresStore(t *testing.T, cfg Config, responder func(query string, args []driver.NamedValue) (driver.Rows, error)) *PostgresStore {
 	t.Helper()
 
-	name := registerStubPostgresDriver(t, responder)
+	name := registerStubPostgresDriver(t, responder, nil)
 	db, err := sql.Open(name, "stub")
 	if err != nil {
 		t.Fatalf("sql.Open(%q): %v", name, err)
@@ -214,7 +317,20 @@ func newStubPostgresStore(t *testing.T, cfg Config, responder func(query string,
 	return &PostgresStore{db: db, cfg: cfg}
 }
 
-func registerStubPostgresDriver(t *testing.T, responder func(query string, args []driver.NamedValue) (driver.Rows, error)) string {
+func newStubPostgresStoreWithExec(t *testing.T, cfg Config, queryResponder func(query string, args []driver.NamedValue) (driver.Rows, error), execResponder func(query string, args []driver.NamedValue) (driver.Result, error)) *PostgresStore {
+	t.Helper()
+
+	name := registerStubPostgresDriver(t, queryResponder, execResponder)
+	db, err := sql.Open(name, "stub")
+	if err != nil {
+		t.Fatalf("sql.Open(%q): %v", name, err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	return &PostgresStore{db: db, cfg: cfg}
+}
+
+func registerStubPostgresDriver(t *testing.T, responder func(query string, args []driver.NamedValue) (driver.Rows, error), execResponder func(query string, args []driver.NamedValue) (driver.Result, error)) string {
 	t.Helper()
 
 	stubPostgresDriverMu.Lock()
@@ -223,6 +339,7 @@ func registerStubPostgresDriver(t *testing.T, responder func(query string, args 
 	stubPostgresDriverSeq++
 	name := fmt.Sprintf("stub-postgres-store-%d", stubPostgresDriverSeq)
 	stubPostgresResponders[name] = responder
+	stubPostgresExecResponders[name] = execResponder
 	sql.Register(name, stubPostgresDriver{name: name})
 	return name
 }
@@ -235,9 +352,11 @@ func (d stubPostgresDriver) Open(string) (driver.Conn, error) {
 
 type stubPostgresConn struct{ name string }
 
-func (c *stubPostgresConn) Prepare(string) (driver.Stmt, error) { return nil, errors.New("not implemented") }
-func (c *stubPostgresConn) Close() error                        { return nil }
-func (c *stubPostgresConn) Begin() (driver.Tx, error)           { return stubPostgresTx{}, nil }
+func (c *stubPostgresConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *stubPostgresConn) Close() error              { return nil }
+func (c *stubPostgresConn) Begin() (driver.Tx, error) { return stubPostgresTx{}, nil }
 
 func (c *stubPostgresConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	stubPostgresDriverMu.Lock()
@@ -249,10 +368,28 @@ func (c *stubPostgresConn) QueryContext(_ context.Context, query string, args []
 	return responder(query, args)
 }
 
+func (c *stubPostgresConn) ExecContext(_ context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	stubPostgresDriverMu.Lock()
+	responder := stubPostgresExecResponders[c.name]
+	stubPostgresDriverMu.Unlock()
+	if responder == nil {
+		return nil, errors.New("missing stub exec responder")
+	}
+	return responder(query, args)
+}
+
 type stubPostgresTx struct{}
 
 func (stubPostgresTx) Commit() error   { return nil }
 func (stubPostgresTx) Rollback() error { return nil }
+
+type stubPostgresResult struct {
+	lastInsertID int64
+	rowsAffected int64
+}
+
+func (r stubPostgresResult) LastInsertId() (int64, error) { return r.lastInsertID, nil }
+func (r stubPostgresResult) RowsAffected() (int64, error) { return r.rowsAffected, nil }
 
 type stubPostgresRows struct {
 	columns []string

--- a/scripts/validate-postgres-local.sh
+++ b/scripts/validate-postgres-local.sh
@@ -6,10 +6,20 @@ COMPOSE_FILE="$ROOT_DIR/docker-compose.postgres.yml"
 TMP_DIR="$ROOT_DIR/.tmp/postgres-validate"
 DATA_DIR="$TMP_DIR/data"
 LOG_FILE="$TMP_DIR/lore.log"
+APP_BIN="$TMP_DIR/lore-validate"
 PORT="17437"
 BASE_URL="http://127.0.0.1:$PORT"
 DATABASE_URL_DEFAULT="postgres://lore:lore@127.0.0.1:5432/lore?sslmode=disable"
 DATABASE_URL_VALUE="${DATABASE_URL:-$DATABASE_URL_DEFAULT}"
+SKILL_NAME="pg-local-hosted-skill-$(date +%s)"
+SKILL_DISPLAY_NAME="PG Local Hosted Skill"
+SKILL_TRIGGERS="When validating hosted postgres MCP skill reads"
+SKILL_CONTENT="# Postgres hosted validation skill"
+SKILL_COMPACT_RULES="Keep answers terse."
+SEED_FILE="$TMP_DIR/seed_skill.go"
+SMOKE_FILE="$TMP_DIR/mcp_skill_smoke.go"
+
+export SKILL_NAME SKILL_DISPLAY_NAME SKILL_TRIGGERS SKILL_CONTENT SKILL_COMPACT_RULES
 
 fail() {
   printf '%s\n' "ERROR: $1" >&2
@@ -40,6 +50,7 @@ if ! command -v python3 >/dev/null 2>&1; then
   fail "python3 binary not found"
 fi
 
+rm -rf "$TMP_DIR"
 mkdir -p "$DATA_DIR"
 rm -f "$LOG_FILE"
 
@@ -48,6 +59,7 @@ cleanup() {
     kill "$APP_PID" >/dev/null 2>&1 || true
     wait "$APP_PID" >/dev/null 2>&1 || true
   fi
+  rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT INT TERM
 
@@ -69,7 +81,12 @@ fi
 LORE_DATA_DIR="$DATA_DIR" \
 LORE_PORT="$PORT" \
 DATABASE_URL="$DATABASE_URL_VALUE" \
-go run ./cmd/lore serve >"$LOG_FILE" 2>&1 &
+go build -o "$APP_BIN" ./cmd/lore
+
+LORE_DATA_DIR="$DATA_DIR" \
+LORE_PORT="$PORT" \
+DATABASE_URL="$DATABASE_URL_VALUE" \
+"$APP_BIN" serve >"$LOG_FILE" 2>&1 &
 APP_PID=$!
 
 attempt=0
@@ -113,9 +130,198 @@ curl -fsS -X POST "$BASE_URL/sessions/pg-local-session/end" \
   -H 'Content-Type: application/json' \
   -d '{"summary":"local postgres validation complete"}' >/dev/null
 
-SEARCH_STATUS="$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/search?q=postgres&project=lore&scope=project&limit=10")"
-if [ "$SEARCH_STATUS" != "500" ]; then
-  fail "expected unsupported PostgreSQL search slice to return HTTP 500, got $SEARCH_STATUS"
-fi
+cat >"$SEED_FILE" <<'EOF'
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/alferio94/lore/internal/store"
+)
+
+func main() {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		panic("DATABASE_URL is required")
+	}
+
+	opened, err := store.Open(store.Config{
+		Backend:              store.BackendPostgreSQL,
+		DatabaseURL:          databaseURL,
+		MaxObservationLength: 50000,
+		MaxContextResults:    20,
+		MaxSearchResults:     20,
+		DedupeWindow:         15 * time.Minute,
+	})
+	if err != nil {
+		panic(fmt.Sprintf("open postgres store: %v", err))
+	}
+	defer opened.Close()
+
+	if _, err := opened.CreateSkill(store.CreateSkillParams{
+		Name:         os.Getenv("SKILL_NAME"),
+		DisplayName:  os.Getenv("SKILL_DISPLAY_NAME"),
+		Triggers:     os.Getenv("SKILL_TRIGGERS"),
+		Content:      os.Getenv("SKILL_CONTENT"),
+		CompactRules: os.Getenv("SKILL_COMPACT_RULES"),
+		ChangedBy:    "validate-postgres-local",
+	}); err != nil {
+		panic(fmt.Sprintf("create skill: %v", err))
+	}
+}
+EOF
+
+DATABASE_URL="$DATABASE_URL_VALUE" \
+SKILL_NAME="$SKILL_NAME" \
+SKILL_DISPLAY_NAME="$SKILL_DISPLAY_NAME" \
+SKILL_TRIGGERS="$SKILL_TRIGGERS" \
+SKILL_CONTENT="$SKILL_CONTENT" \
+SKILL_COMPACT_RULES="$SKILL_COMPACT_RULES" \
+go run "$SEED_FILE" >/dev/null
+
+cat >"$SMOKE_FILE" <<'EOF'
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func main() {
+	baseURL := strings.TrimRight(os.Getenv("BASE_URL"), "/")
+	if baseURL == "" {
+		panic("BASE_URL is required")
+	}
+	mcpURL := baseURL + "/mcp"
+	skillName := os.Getenv("SKILL_NAME")
+	compactRules := os.Getenv("SKILL_COMPACT_RULES")
+	skillContent := os.Getenv("SKILL_CONTENT")
+
+	_ = post(mcpURL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2024-11-05",
+			"capabilities":    map[string]any{},
+			"clientInfo": map[string]any{
+				"name":    "postgres-local-validator",
+				"version": "1.0",
+			},
+		},
+	})
+
+	listBody := post(mcpURL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "lore_list_skills",
+			"arguments": map[string]any{
+				"query": skillName,
+			},
+		},
+	})
+	listText := firstText(listBody)
+	if !strings.Contains(listText, skillName) || strings.Contains(listText, "compact_rules") {
+		panic(fmt.Sprintf("unexpected lore_list_skills response: %s", listText))
+	}
+
+	getBody := post(mcpURL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      3,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "lore_get_skill",
+			"arguments": map[string]any{
+				"name": skillName,
+			},
+		},
+	})
+	getText := firstText(getBody)
+	if !strings.Contains(getText, skillName) || !strings.Contains(getText, compactRules) || !strings.Contains(getText, skillContent) {
+		panic(fmt.Sprintf("unexpected lore_get_skill response: %s", getText))
+	}
+
+	resourceBody := post(mcpURL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      4,
+		"method":  "resources/read",
+		"params": map[string]any{
+			"uri": "skills://" + skillName,
+		},
+	})
+	result, ok := resourceBody["result"].(map[string]any)
+	if !ok {
+		panic(fmt.Sprintf("resource result missing: %v", resourceBody))
+	}
+	contents, ok := result["contents"].([]any)
+	if !ok || len(contents) == 0 {
+		panic(fmt.Sprintf("resource contents missing: %v", result["contents"]))
+	}
+	resource, ok := contents[0].(map[string]any)
+	if !ok {
+		panic(fmt.Sprintf("unexpected resource payload: %T", contents[0]))
+	}
+	if resource["mimeType"] != "text/markdown" || resource["uri"] != "skills://"+skillName || !strings.Contains(fmt.Sprint(resource["text"]), skillContent) {
+		panic(fmt.Sprintf("unexpected resource response: %+v", resource))
+	}
+}
+
+func post(url string, payload map[string]any) map[string]any {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		panic(fmt.Sprintf("marshal payload: %v", err))
+	}
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		panic(fmt.Sprintf("POST %s: %v", url, err))
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		panic(fmt.Sprintf("POST %s: unexpected HTTP %d body=%s", url, resp.StatusCode, string(raw)))
+	}
+	var decoded map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		panic(fmt.Sprintf("decode response: %v", err))
+	}
+	return decoded
+}
+
+func firstText(body map[string]any) string {
+	result, ok := body["result"].(map[string]any)
+	if !ok {
+		panic(fmt.Sprintf("tool result missing: %v", body))
+	}
+	content, ok := result["content"].([]any)
+	if !ok || len(content) == 0 {
+		panic(fmt.Sprintf("tool content missing: %v", result["content"]))
+	}
+	item, ok := content[0].(map[string]any)
+	if !ok {
+		panic(fmt.Sprintf("unexpected content payload: %T", content[0]))
+	}
+	text, _ := item["text"].(string)
+	if text == "" {
+		panic(fmt.Sprintf("missing text payload: %v", item))
+	}
+	return text
+}
+EOF
+
+DATABASE_URL="$DATABASE_URL_VALUE" \
+BASE_URL="$BASE_URL" \
+SKILL_NAME="$SKILL_NAME" \
+SKILL_COMPACT_RULES="$SKILL_COMPACT_RULES" \
+SKILL_CONTENT="$SKILL_CONTENT" \
+go run "$SMOKE_FILE" >/dev/null
 
 printf '%s\n' "Local PostgreSQL validation passed."


### PR DESCRIPTION
Closes #18

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds PostgreSQL bootstrap/schema support for the skill catalog, relationships, versions, users, and related indexes.
- Implements PostgreSQL skill catalog, user, and admin stats parity in `PostgresStore` with focused integration coverage.
- Updates the local PostgreSQL validation path to smoke skill catalog reads through the real HTTP `/mcp` runtime.

## Changes
| File | Change |
|------|--------|
| `internal/store/backend/postgres/postgres.go` | Adds additive skill catalog/user schema and version uniqueness index. |
| `internal/store/postgres_store.go` | Implements PostgreSQL skill, stack, category, version, user, and admin stats methods. |
| `internal/store/postgres_integration_test.go` | Adds real Postgres parity coverage, including concurrency regressions. |
| `internal/mcp/mcp_test.go` | Adds PostgreSQL-backed MCP skill catalog smoke coverage. |
| `scripts/validate-postgres-local.sh` | Validates skill catalog MCP reads against the real `lore serve` `/mcp` endpoint and cleans temp files. |
| `README.md`, `docs/INSTALLATION.md` | Align hosted PostgreSQL validation guidance with skill catalog support. |

## Test Plan
- [x] `go test ./internal/store/backend/postgres -run 'Test(OpenDatabase|NormalizeDSN)'`
- [x] `go test ./internal/store -run 'TestPostgresStoreBootstrapAndPingIntegration'`
- [x] `go test ./internal/store -run 'TestPostgresStore(Search|.*Skill|.*Stack|.*Category|UnsupportedPrompt)'`
- [x] `go test ./internal/store -run 'Test(PostgresStore.*User|PostgresStore.*Stats|PostgresStore.*Search|Store.*AdminStats|Store.*UpsertUser)'`
- [x] `go test ./internal/mcp -run 'TestHandle(ListSkills|GetSkill|SkillResource).*'`
- [x] `scripts/validate-postgres-local.sh`
- [x] SDD verify passed with warnings
- [x] Judgment Day Round 2 approved

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran unit tests locally
- [x] Ran e2e/local validation where relevant
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Notes
- Public MCP auth/roles, agent-proposed skill review workflow, web/dashboard UI, and broad non-additive migration framework are intentionally out of scope.
- Existing corrupted databases with duplicate `(skill_id, version)` rows may need a future cleanup migration before the new unique index can apply.